### PR TITLE
feat(security): externalize secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ To build the app, just run:
     
 This will build a standalone jar at `backend/build/libs/globe42.jar`, that you can run with:
 
-    java -jar backend/build/libs/globe42.jar
+    java -jar backend/build/libs/globe42.jar --globe42.secretKey=<some secret key>
     
 And the full app runs on http://localhost:9000

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,10 @@ bootJar {
     }
 }
 
+bootRun {
+    args '--globe42.secretKey=QMwbcwa19VV02Oy5T7LSWyV+/wZrOsRRfhCR6TkapsY='
+}
+
 dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compile 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/src/main/java/org/globe42/web/security/JwtHelper.java
+++ b/backend/src/main/java/org/globe42/web/security/JwtHelper.java
@@ -1,8 +1,14 @@
 package org.globe42.web.security;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -12,16 +18,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtHelper {
 
-    public static final String DEFAULT_SECRET_KEY = "globe42!";
+    public static final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithm.HS256;
 
     private final String secretKey;
 
-    public JwtHelper(String secretKey) {
+    public JwtHelper(@Value("${globe42.secretKey}") String secretKey) {
         this.secretKey = secretKey;
-    }
-
-    public JwtHelper() {
-        this(DEFAULT_SECRET_KEY);
     }
 
     /**
@@ -33,7 +35,7 @@ public class JwtHelper {
     public String buildToken(Long userId) {
         return Jwts.builder()
                    .setSubject(userId.toString())
-                   .signWith(SignatureAlgorithm.HS256, secretKey).compact();
+                   .signWith(SIGNATURE_ALGORITHM, secretKey).compact();
     }
 
     /**
@@ -44,5 +46,14 @@ public class JwtHelper {
      */
     public Claims extractClaims(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+    }
+
+    /**
+     * Allows generating a real secret key
+     */
+    public static void main(String[] args) throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(SIGNATURE_ALGORITHM.getJcaName());
+        SecretKey secretKey = keyGenerator.generateKey();
+        System.out.println(Base64.getEncoder().encodeToString(secretKey.getEncoded()));
     }
 }

--- a/backend/src/test/java/org/globe42/CrypticApplicationTest.java
+++ b/backend/src/test/java/org/globe42/CrypticApplicationTest.java
@@ -3,11 +3,13 @@ package org.globe42;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class CrypticApplicationTests {
+@TestPropertySource("/test.properties")
+public class CrypticApplicationTest {
 
 	@Test
 	public void contextLoads() {

--- a/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public abstract class BaseDaoTest {
     protected static final DbSetupTracker TRACKER = new DbSetupTracker();
 
-    private final Operation DELETE_ALL = DeleteAll.from("guser", "PERSON");
+    private final Operation DELETE_ALL = DeleteAll.from("PERSON", "GUSER");
 
     @Autowired
     private DataSource dataSource;

--- a/backend/src/test/java/org/globe42/web/security/JwtHelperTest.java
+++ b/backend/src/test/java/org/globe42/web/security/JwtHelperTest.java
@@ -15,7 +15,7 @@ public class JwtHelperTest {
 
     @Before
     public void prepare() {
-        jwtHelper = new JwtHelper();
+        jwtHelper = new JwtHelper("someSecretKey");
     }
 
     @Test

--- a/backend/src/test/resources/test.properties
+++ b/backend/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 spring.datasource.url=jdbc:postgresql:globe42_test
 
+globe42.secretKey=QMwbcwa19VV02Oy5T7LSWyV+/wZrOsRRfhCR6TkapsY=


### PR DESCRIPTION
Also fix the DAO tests and renamed the main test.

Since the repo is public, we don't want to expose the actual secret key used to generate tokens. We also might want to change it fast, without having to redeploy.

So the key is now externalized. What this means is that

 - integration tests that use a non-mocked JwtHelper bean must add the `globe42.secretKey` to their environment. That is easily done using the test.properties file. See `CrypticApplicationTest` for an example.
 - run configurations that start the application must define this property, too. This can be done using an environment variable or a command-line argument: `
--globe42.secretKey=QMwbcwa19VV02Oy5T7LSWyV+/wZrOsRRfhCR6TkapsY=`
 - when deployed in production, we'll have to do the same thing. Alternatives are described in https://docs.spring.io/spring-boot/docs/2.0.0.M1/reference/htmlsingle/#howto-externalize-configuration

 The JwtHelper class now also has a main method that can be used to generate an actual, random secret key, with the appropriate size for the algorithm.