### PR TITLE
build: add test coverage to frontend

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -14,8 +14,6 @@ node {
   download = true
 }
 
-clean.dependsOn 'cleanNpm_run_build'
-
 npm_run_build {
   dependsOn 'yarn_install'
   inputs.dir 'src'
@@ -24,7 +22,7 @@ npm_run_build {
 
 npm_run_test {
   inputs.dir 'src'
-  outputs.upToDateWhen { true }
+  outputs.dir 'coverage'
 }
 
 yarn_install {
@@ -40,3 +38,6 @@ task test {
 check {
   dependsOn test
 }
+
+clean.dependsOn 'cleanNpm_run_build'
+clean.dependsOn 'cleanNpm_run_test'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build --prod",
-    "test": "ng test --single-run",
+    "test": "ng test --single-run --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
Besides the advantage of having coverage information, this is also useful to make sure the frontend tests are rerun after a clean. Indeed, since the test task had no output, tests were not rerun after a clean if the test task inputs had not changed, which is a bit surprising.