### PR TITLE
add user admin (dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,10 @@ This will build a standalone jar at `backend/build/libs/globe42.jar`, that you c
 
     java -jar backend/build/libs/globe42.jar --globe42.secretKey=<some secret key>
     
+
+To start the application with the demo profile, add this command-line option:  
+    
+    --spring.profiles.active=demo
+    
 And the full app runs on http://localhost:9000
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,3 +19,9 @@ spring:
     password: globe42
     hikari:
       maximum-pool-size: 5
+
+---
+spring:
+  profiles: demo
+flyway:
+  locations: classpath:/db/migration,classpath:/demo/db/migration

--- a/backend/src/main/resources/demo/db/migration/V0004__user_insert.sql
+++ b/backend/src/main/resources/demo/db/migration/V0004__user_insert.sql
@@ -1,0 +1,1 @@
+INSERT INTO guser (id, login, password) VALUES(1, 'admin', 's5wqy52qDD53eL6mVUFqiAuruW/wgpo5H9wv3IdDqz7WqyPjFOaxEQ==');


### PR DESCRIPTION
I didn't find a data file with the admin user (as explained in Slack), so I've used the PasswordDigesterTest to generate the data for the user admin and I added these data in a file under the backend/src/main/resources/db.migration directory
Such a user is mandatory to dev/test the application and do the demo