### PR TITLE
feat(users): add CRUD services for users, and password resets/changes

### DIFF
--- a/backend/src/main/java/org/globe42/dao/UserDao.java
+++ b/backend/src/main/java/org/globe42/dao/UserDao.java
@@ -11,4 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface UserDao extends JpaRepository<User, Long> {
     Optional<User> findByLogin(String login);
+
+    boolean existsByLogin(String login);
 }

--- a/backend/src/main/java/org/globe42/web/security/AuthenticatedUserDTO.java
+++ b/backend/src/main/java/org/globe42/web/security/AuthenticatedUserDTO.java
@@ -6,12 +6,12 @@ import org.globe42.domain.User;
  * A user, with its JWT token
  * @author JB Nizet
  */
-public final class UserDTO {
+public final class AuthenticatedUserDTO {
     private Long id;
     private final String login;
     private final String token;
 
-    public UserDTO(User user, String token) {
+    public AuthenticatedUserDTO(User user, String token) {
         this.id = user.getId();
         this.login = user.getLogin();
         this.token = token;

--- a/backend/src/main/java/org/globe42/web/security/AuthenticationController.java
+++ b/backend/src/main/java/org/globe42/web/security/AuthenticationController.java
@@ -32,12 +32,12 @@ public class AuthenticationController {
     }
 
     @PostMapping
-    public UserDTO authenticate(@RequestBody CredentialsDTO credentials) {
+    public AuthenticatedUserDTO authenticate(@RequestBody CredentialsDTO credentials) {
         User user = userDao.findByLogin(credentials.getLogin()).orElseThrow(UnauthorizedException::new);
         if (!passwordDigester.match(credentials.getPassword(), user.getPassword())) {
             throw new UnauthorizedException();
         }
 
-        return new UserDTO(user, jwtHelper.buildToken(user.getId()));
+        return new AuthenticatedUserDTO(user, jwtHelper.buildToken(user.getId()));
     }
 }

--- a/backend/src/main/java/org/globe42/web/users/ChangePasswordCommandDTO.java
+++ b/backend/src/main/java/org/globe42/web/users/ChangePasswordCommandDTO.java
@@ -1,0 +1,23 @@
+package org.globe42.web.users;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * Command sent to change the password of the current user
+ * @author JB Nizet
+ */
+public final class ChangePasswordCommandDTO {
+    @NotEmpty
+    private String newPassword;
+
+    @JsonCreator
+    public ChangePasswordCommandDTO(@JsonProperty String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/users/PasswordGenerator.java
+++ b/backend/src/main/java/org/globe42/web/users/PasswordGenerator.java
@@ -1,0 +1,37 @@
+package org.globe42.web.users;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * A random password generator
+ * @author JB Nizet
+ */
+@Component
+public class PasswordGenerator {
+
+    private static final int SIZE = 8;
+    private static final char[] CHARACTERS =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_$%?/+=.<>#*".toCharArray();
+
+    private SecureRandom random;
+
+    public PasswordGenerator() {
+        try {
+            random = SecureRandom.getInstance("SHA1PRNG");
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public String generatePassword() {
+        StringBuilder builder = new StringBuilder(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            builder.append(CHARACTERS[random.nextInt(CHARACTERS.length)]);
+        }
+        return builder.toString();
+    }
+}

--- a/backend/src/main/java/org/globe42/web/users/UserCommandDTO.java
+++ b/backend/src/main/java/org/globe42/web/users/UserCommandDTO.java
@@ -1,0 +1,27 @@
+package org.globe42.web.users;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * Command passed to create or update a user
+ * @author JB Nizet
+ */
+public final class UserCommandDTO {
+
+    /**
+     * The new login of the user.
+     */
+    @NotEmpty
+    private final String login;
+
+    @JsonCreator
+    public UserCommandDTO(@JsonProperty String login) {
+        this.login = login;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/users/UserController.java
+++ b/backend/src/main/java/org/globe42/web/users/UserController.java
@@ -1,17 +1,29 @@
 package org.globe42.web.users;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
+import org.globe42.web.exception.BadRequestException;
 import org.globe42.web.exception.NotFoundException;
 import org.globe42.web.security.CurrentUser;
+import org.globe42.web.security.PasswordDigester;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Controller used to handle users
+ * Controller used to handle users and their passwords
  * @author JB Nizet
  */
 @RestController
@@ -21,15 +33,88 @@ public class UserController {
 
     private final CurrentUser currentUser;
     private final UserDao userDao;
+    private final PasswordGenerator passwordGenerator;
+    private final PasswordDigester passwordDigester;
 
-    public UserController(CurrentUser currentUser, UserDao userDao) {
+    public UserController(CurrentUser currentUser,
+                          UserDao userDao,
+                          PasswordGenerator passwordGenerator,
+                          PasswordDigester passwordDigester) {
         this.currentUser = currentUser;
         this.userDao = userDao;
+        this.passwordGenerator = passwordGenerator;
+        this.passwordDigester = passwordDigester;
     }
 
     @GetMapping("/me")
     public CurrentUserDTO getCurrentUser() {
         User user = userDao.findById(currentUser.getUserId()).orElseThrow(NotFoundException::new);
         return new CurrentUserDTO(user);
+    }
+
+    @PutMapping("/me/passwords")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changePassword(@Validated @RequestBody ChangePasswordCommandDTO command) {
+        User user = userDao.findById(currentUser.getUserId()).orElseThrow(NotFoundException::new);
+        user.setPassword(passwordDigester.hash(command.getNewPassword()));
+    }
+
+    @GetMapping
+    public List<UserDTO> list() {
+        return userDao.findAll().stream().map(UserDTO::new).collect(Collectors.toList());
+    }
+
+    @GetMapping("/{userId}")
+    public UserDTO get(@PathVariable("userId") Long userId) {
+        return userDao.findById(userId).map(UserDTO::new).orElseThrow(NotFoundException::new);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserWithPasswordDTO create(@Validated @RequestBody UserCommandDTO command) {
+        if (userDao.existsByLogin(command.getLogin())) {
+            throw new BadRequestException("This login is already used by another user");
+        }
+
+        User user = new User();
+        copyCommandToUser(command, user);
+
+        String generatedPassword = passwordGenerator.generatePassword();
+        user.setPassword(passwordDigester.hash(generatedPassword));
+
+        userDao.save(user);
+
+        return new UserWithPasswordDTO(user, generatedPassword);
+    }
+
+    @PutMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(@PathVariable("userId") Long userId, @Validated @RequestBody UserCommandDTO command) {
+        User user = userDao.findById(userId).orElseThrow(() -> new NotFoundException("No user with ID " + userId));
+
+        userDao.findByLogin(command.getLogin()).filter(other -> !other.getId().equals(userId)).ifPresent(other -> {
+            throw new BadRequestException("This login is already used by another user");
+        });
+
+        copyCommandToUser(command, user);
+    }
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable("userId") Long userId) {
+        userDao.findById(userId).ifPresent(userDao::delete);
+    }
+
+    @PostMapping("/{userId}/password-resets")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserWithPasswordDTO resetPassword(@PathVariable("userId") Long userId) {
+        User user = userDao.findById(userId).orElseThrow(() -> new NotFoundException("No user with ID " + userId));
+        String generatedPassword = passwordGenerator.generatePassword();
+        user.setPassword(passwordDigester.hash(generatedPassword));
+        return new UserWithPasswordDTO(user, generatedPassword);
+    }
+
+    private void copyCommandToUser(UserCommandDTO command, User user) {
+        user.setLogin(command.getLogin());
     }
 }

--- a/backend/src/main/java/org/globe42/web/users/UserDTO.java
+++ b/backend/src/main/java/org/globe42/web/users/UserDTO.java
@@ -1,0 +1,25 @@
+package org.globe42.web.users;
+
+import org.globe42.domain.User;
+
+/**
+ * A user of the application
+ * @author JB Nizet
+ */
+public final class UserDTO {
+    private final Long id;
+    private final String login;
+
+    public UserDTO(User user) {
+        this.id = user.getId();
+        this.login = user.getLogin();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/users/UserWithPasswordDTO.java
+++ b/backend/src/main/java/org/globe42/web/users/UserWithPasswordDTO.java
@@ -1,0 +1,30 @@
+package org.globe42.web.users;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import org.globe42.domain.User;
+
+/**
+ * The information returned by a user creation. It contains a generated password, that must be transferred
+ * to the actual user.
+ * @author JB Nizet
+ */
+public final class UserWithPasswordDTO {
+
+    @JsonUnwrapped
+    private final UserDTO user;
+
+    private final String generatedPassword;
+
+    public UserWithPasswordDTO(User user, String generatedPassword) {
+        this.user = new UserDTO(user);
+        this.generatedPassword = generatedPassword;
+    }
+
+    public UserDTO getUser() {
+        return user;
+    }
+
+    public String getGeneratedPassword() {
+        return generatedPassword;
+    }
+}

--- a/backend/src/test/java/org/globe42/dao/UserDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/UserDaoTest.java
@@ -33,4 +33,11 @@ public class UserDaoTest extends BaseDaoTest {
         assertThat(userDao.findByLogin("jb")).isNotEmpty();
         assertThat(userDao.findByLogin("ced")).isEmpty();
     }
+
+    @Test
+    public void shouldExistByLogin() {
+        TRACKER.skipNextLaunch();
+        assertThat(userDao.existsByLogin("jb")).isTrue();
+        assertThat(userDao.existsByLogin("ced")).isFalse();
+    }
 }

--- a/backend/src/test/java/org/globe42/web/incomes/IncomeSourceTypeControllerTest.java
+++ b/backend/src/test/java/org/globe42/web/incomes/IncomeSourceTypeControllerTest.java
@@ -77,6 +77,18 @@ public class IncomeSourceTypeControllerTest extends BaseTest {
         assertIncomeSourceTypeEqualsCommand(incomeSourceTypeArgumentCaptor.getValue(), command);
     }
 
+    @Test
+    public void shouldUpdate() {
+        IncomeSourceTypeCommandDTO command = createCommand();
+
+        when(mockIncomeSourceTypeDao.findById(incomeSourceType.getId())).thenReturn(Optional.of(incomeSourceType));
+        when(mockIncomeSourceTypeDao.findByType(command.getType())).thenReturn(Optional.empty());
+
+        controller.update(incomeSourceType.getId(), command);
+
+        assertIncomeSourceTypeEqualsCommand(incomeSourceType, command);
+    }
+
     static IncomeSourceTypeCommandDTO createCommand() {
         return new IncomeSourceTypeCommandDTO("Securité Sociale");
     }

--- a/backend/src/test/java/org/globe42/web/security/AuthenticationControllerTest.java
+++ b/backend/src/test/java/org/globe42/web/security/AuthenticationControllerTest.java
@@ -59,7 +59,7 @@ public class AuthenticationControllerTest extends BaseTest {
         when(mockPasswordDigester.match(credentials.getPassword(), user.getPassword())).thenReturn(true);
         String token = "token";
         when(mockJwtHelper.buildToken(user.getId())).thenReturn(token);
-        UserDTO result = controller.authenticate(credentials);
+        AuthenticatedUserDTO result = controller.authenticate(credentials);
 
         assertThat(result.getId()).isEqualTo(user.getId());
         assertThat(result.getLogin()).isEqualTo(user.getLogin());

--- a/backend/src/test/java/org/globe42/web/users/PasswordGeneratorTest.java
+++ b/backend/src/test/java/org/globe42/web/users/PasswordGeneratorTest.java
@@ -1,0 +1,22 @@
+package org.globe42.web.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PasswordGenerator}
+ * @author JB Nizet
+ */
+public class PasswordGeneratorTest {
+    @Test
+    public void shouldGenerate() {
+        PasswordGenerator passwordGenerator = new PasswordGenerator();
+
+        String p1 = passwordGenerator.generatePassword();
+        String p2 = passwordGenerator.generatePassword();
+        assertThat(p1).hasSize(8);
+        assertThat(p2).hasSize(8);
+        assertThat(p1).isNotEqualTo(p2);
+    }
+}

--- a/backend/src/test/java/org/globe42/web/users/UserControllerMvcTest.java
+++ b/backend/src/test/java/org/globe42/web/users/UserControllerMvcTest.java
@@ -1,20 +1,24 @@
 package org.globe42.web.users;
 
+import static org.globe42.test.JsonTestUtil.OBJECT_MAPPER;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
 import org.globe42.test.GlobeMvcTest;
 import org.globe42.web.security.CurrentUser;
+import org.globe42.web.security.PasswordDigester;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,6 +35,12 @@ public class UserControllerMvcTest {
     @MockBean
     private UserDao mockUserDao;
 
+    @MockBean
+    private PasswordGenerator mockPasswordGenerator;
+
+    @MockBean
+    private PasswordDigester mockPasswordDigester;
+
     @Autowired
     private MockMvc mvc;
 
@@ -45,5 +55,82 @@ public class UserControllerMvcTest {
            .andExpect(jsonPath("$.id").value(user.getId()))
            .andExpect(jsonPath("$.login").value(user.getLogin()))
            .andExpect(jsonPath("$.password").doesNotExist());
+    }
+
+    @Test
+    public void shouldChangePasswordOfCurrentUser() throws Exception {
+        User user = UserControllerTest.createUser(42L);
+        when(mockCurrentUser.getUserId()).thenReturn(user.getId());
+        when(mockUserDao.findById(user.getId())).thenReturn(Optional.of(user));
+
+        ChangePasswordCommandDTO command = new ChangePasswordCommandDTO("newPassword");
+
+        mvc.perform(put("/api/users/me/passwords")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(OBJECT_MAPPER.writeValueAsBytes(command)))
+           .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void shouldList() throws Exception {
+        User user = UserControllerTest.createUser(42L);
+        when(mockUserDao.findAll()).thenReturn(Collections.singletonList(user));
+
+        mvc.perform(get("/api/users"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$[0].id").value(user.getId()))
+           .andExpect(jsonPath("$[0].login").value(user.getLogin()))
+           .andExpect(jsonPath("$[0].password").doesNotExist());
+    }
+
+    @Test
+    public void shouldCreate() throws Exception {
+        UserCommandDTO command = new UserCommandDTO("test");
+
+        when(mockPasswordGenerator.generatePassword()).thenReturn("password");
+        when(mockPasswordDigester.hash("password")).thenReturn("hashed");
+
+        mvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(OBJECT_MAPPER.writeValueAsBytes(command)))
+           .andExpect(status().isCreated())
+           .andExpect(jsonPath("$.login").value(command.getLogin()))
+           .andExpect(jsonPath("$.generatedPassword").value("password"));
+    }
+
+    @Test
+    public void shouldUpdate() throws Exception {
+        User user = UserControllerTest.createUser(42L);
+        when(mockUserDao.findById(user.getId())).thenReturn(Optional.of(user));
+
+        UserCommandDTO command = new UserCommandDTO("test");
+
+        mvc.perform(put("/api/users/{userId}", user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsBytes(command)))
+           .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void shouldDelete() throws Exception {
+        User user = UserControllerTest.createUser(42L);
+        when(mockUserDao.findById(user.getId())).thenReturn(Optional.of(user));
+
+        mvc.perform(delete("/api/users/{userId}", user.getId()))
+           .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void shouldResetPassword() throws Exception {
+        User user = UserControllerTest.createUser(42L);
+        when(mockUserDao.findById(user.getId())).thenReturn(Optional.of(user));
+
+        when(mockPasswordGenerator.generatePassword()).thenReturn("password");
+        when(mockPasswordDigester.hash("password")).thenReturn("hashed");
+
+        mvc.perform(post("/api/users/{userId}/password-resets", user.getId()))
+           .andExpect(status().isCreated())
+           .andExpect(jsonPath("$.login").value(user.getLogin()))
+           .andExpect(jsonPath("$.generatedPassword").value("password"));
     }
 }

--- a/backend/src/test/java/org/globe42/web/users/UserControllerTest.java
+++ b/backend/src/test/java/org/globe42/web/users/UserControllerTest.java
@@ -1,17 +1,26 @@
 package org.globe42.web.users;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
 import org.globe42.test.BaseTest;
+import org.globe42.web.exception.BadRequestException;
 import org.globe42.web.exception.NotFoundException;
 import org.globe42.web.security.CurrentUser;
+import org.globe42.web.security.PasswordDigester;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -26,8 +35,17 @@ public class UserControllerTest extends BaseTest{
     @Mock
     private UserDao mockUserDao;
 
+    @Mock
+    private PasswordGenerator mockPasswordGenerator;
+
+    @Mock
+    private PasswordDigester mockPasswordDigester;
+
     @InjectMocks
     private UserController controller;
+
+    @Captor
+    private ArgumentCaptor<User> userCaptor;
 
     private Long userId = 42L;
 
@@ -47,10 +65,137 @@ public class UserControllerTest extends BaseTest{
     }
 
     @Test(expected = NotFoundException.class)
-    public void shouldThrowIfNotFound() {
+    public void shouldThrowWhenGettingCurrentUserIfNotFound() {
         when(mockUserDao.findById(userId)).thenReturn(Optional.empty());
 
         controller.getCurrentUser();
+    }
+
+    @Test
+    public void shouldChangePasswordOfCurrentUser() {
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        ChangePasswordCommandDTO command = new ChangePasswordCommandDTO("newPassword");
+        when(mockPasswordDigester.hash(command.getNewPassword())).thenReturn("hashed");
+
+        controller.changePassword(command);
+
+        assertThat(user.getPassword()).isEqualTo("hashed");
+    }
+
+    @Test
+    public void shouldList() {
+        User user = createUser(userId);
+        when(mockUserDao.findAll()).thenReturn(Collections.singletonList(user));
+
+        List<UserDTO> result = controller.list();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(user.getId());
+        assertThat(result.get(0).getLogin()).isEqualTo(user.getLogin());
+    }
+
+    @Test
+    public void shouldGet() {
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        UserDTO result = controller.get(userId);
+        assertThat(result.getId()).isEqualTo(user.getId());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void shouldThrowWhenGettingIfNotFound() {
+        when(mockUserDao.findById(userId)).thenReturn(Optional.empty());
+        controller.get(userId);
+    }
+
+    @Test
+    public void shouldCreate() {
+        UserCommandDTO command = new UserCommandDTO("test");
+
+        when(mockPasswordGenerator.generatePassword()).thenReturn("password");
+        when(mockPasswordDigester.hash("password")).thenReturn("hashed");
+
+        UserWithPasswordDTO result = controller.create(command);
+        assertThat(result.getGeneratedPassword()).isEqualTo("password");
+        assertThat(result.getUser().getLogin()).isEqualTo(command.getLogin());
+
+        verify(mockUserDao).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getPassword()).isEqualTo("hashed");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowWhenCreatingWithExistingLogin() {
+        UserCommandDTO command = new UserCommandDTO("test");
+
+        when(mockUserDao.existsByLogin(command.getLogin())).thenReturn(true);
+
+        controller.create(command);
+    }
+
+    @Test
+    public void shouldUpdate() {
+        UserCommandDTO command = new UserCommandDTO("test");
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        controller.update(userId, command);
+        assertThat(user.getLogin()).isEqualTo(command.getLogin());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowWhenUpdatingWithExistingLogin() {
+        UserCommandDTO command = new UserCommandDTO("test");
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        when(mockUserDao.findByLogin(command.getLogin())).thenReturn(Optional.of(createUser(4567L)));
+
+        controller.update(userId, command);
+    }
+
+    @Test
+    public void shouldNotThrowWhenUpdatingWithSameLogin() {
+        User user = createUser(userId);
+        UserCommandDTO command = new UserCommandDTO(user.getLogin());
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        when(mockUserDao.findByLogin(command.getLogin())).thenReturn(Optional.of(user));
+
+        controller.update(userId, command);
+    }
+
+    @Test
+    public void shouldDelete() {
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        controller.delete(userId);
+
+        verify(mockUserDao).delete(user);
+    }
+
+    @Test
+    public void shouldNotDoAnythingWhenDeletingUnexistingUser() {
+        when(mockUserDao.findById(userId)).thenReturn(Optional.empty());
+
+        controller.delete(userId);
+
+        verify(mockUserDao, never()).delete(any(User.class));
+    }
+
+    @Test
+    public void shouldResetPassword() {
+        User user = createUser(userId);
+        when(mockUserDao.findById(userId)).thenReturn(Optional.of(user));
+
+        when(mockPasswordGenerator.generatePassword()).thenReturn("password");
+        when(mockPasswordDigester.hash("password")).thenReturn("hashed");
+        UserWithPasswordDTO result = controller.resetPassword(userId);
+
+        assertThat(user.getPassword()).isEqualTo("hashed");
+        assertThat(result.getGeneratedPassword()).isEqualTo("password");
     }
 
     public static User createUser(Long id) {


### PR DESCRIPTION
The user model is limited to login for now, but it will probably contain roles and maybe email in the future.

The intended usage of the API is that an admin creates a user, gets the automatically generated password and gives the login and password to the actual user, which is then free to change his password.

We could imagine storing a flag indicating that the password is auto-generated and force the user to change it, but it's probably useless, since the admin can reset the password anyway, and thus act as the other users.