### PR TITLE
Feat/errors (WIP)

### DIFF
--- a/backend/src/main/java/org/globe42/web/exception/BadRequestException.java
+++ b/backend/src/main/java/org/globe42/web/exception/BadRequestException.java
@@ -1,15 +1,55 @@
 package org.globe42.web.exception;
 
+import java.util.Collections;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
- * Exception thrown to signal thet a request is incorrect. Translated to a 400 HTTP status.
+ * Exception thrown to signal that a request is incorrect. Translated to a 400 HTTP status.
+ * It contains an error containing a code and error parameters, that allows the backend to display a parameterized
+ * error message when getting such an error response.
  * @author JB Nizet
  */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class BadRequestException extends RuntimeException {
+
+    private FunctionalError error;
+
+    /**
+     * Should be used seldomly: it doesn't add any functional error. This constructor is useful
+     * to signal an error that is semantically a bad request, but which should theoretically never happen,
+     * and should thus not lead to a functional error message being displayed.
+     */
     public BadRequestException(String message) {
         super(message);
+    }
+
+    /**
+     * Creates a BadRequestException with a functional error
+     */
+    public BadRequestException(FunctionalError error) {
+        super(error.getCode().toString());
+        this.error = error;
+    }
+
+    /**
+     * Creates a BadRequestException with a functional error with the given code, and no parameter
+     */
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode.toString());
+        this.error = new FunctionalError(errorCode, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a BadRequestException with a functional error with the given code, and a single parameter
+     */
+    public BadRequestException(ErrorCode errorCode, String parameterName, Object parameterValue) {
+        super(errorCode.toString());
+        this.error = new FunctionalError(errorCode, Collections.singletonMap(parameterName, parameterValue));
+    }
+
+    public FunctionalError getError() {
+        return error;
     }
 }

--- a/backend/src/main/java/org/globe42/web/exception/ErrorCode.java
+++ b/backend/src/main/java/org/globe42/web/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package org.globe42.web.exception;
+
+/**
+ * TODO include class javadoc here
+ * @author JB Nizet
+ */
+public enum ErrorCode {
+    USER_LOGIN_ALREADY_EXISTS,
+    INCOME_SOURCE_TYPE_NAME_ALREADY_EXISTS,
+    INCOME_SOURCE_NAME_ALREADY_EXISTS
+}

--- a/backend/src/main/java/org/globe42/web/exception/ExceptionConfig.java
+++ b/backend/src/main/java/org/globe42/web/exception/ExceptionConfig.java
@@ -1,0 +1,46 @@
+package org.globe42.web.exception;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * Spring Configuration class that adds a custom {@link ErrorAttributes} bean to the context, in order to
+ * add a <code>functionalError</code> attribute to the JSON body of error responses when the exception
+ * is a {@link BadRequestException}
+ * @author JB Nizet
+ */
+@Configuration
+public class ExceptionConfig {
+    @Bean
+    public ErrorAttributes errorAttributes() {
+        return new CustomErrorAttributes();
+    }
+
+    public static class CustomErrorAttributes extends DefaultErrorAttributes {
+        public CustomErrorAttributes() {
+        }
+
+        public CustomErrorAttributes(boolean includeException) {
+            super(includeException);
+        }
+
+        @Override
+        public Map<String, Object> getErrorAttributes(WebRequest webRequest, boolean includeStackTrace) {
+            Map<String, Object> result = super.getErrorAttributes(webRequest, includeStackTrace);
+
+            Throwable error = getError(webRequest);
+            if (error instanceof BadRequestException) {
+                BadRequestException exception = (BadRequestException) error;
+                if (exception.getError() != null) {
+                    result.put("functionalError", exception.getError());
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/backend/src/main/java/org/globe42/web/exception/FunctionalError.java
+++ b/backend/src/main/java/org/globe42/web/exception/FunctionalError.java
@@ -1,0 +1,37 @@
+package org.globe42.web.exception;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A functional error, sent as part of an error response body.
+ * @author JB Nizet
+ */
+public class FunctionalError {
+
+    /**
+     * The code of the error
+     */
+    private final ErrorCode code;
+
+    /**
+     * The parameters of the error. The values can be of any type, but must be serializable to JSON. They should most
+     * of the time be simple strings or numbers.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final Map<String, Object> parameters;
+
+    public FunctionalError(ErrorCode code, Map<String, Object> parameters) {
+        this.code = code;
+        this.parameters = parameters;
+    }
+
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/incomes/IncomeSourceController.java
+++ b/backend/src/main/java/org/globe42/web/incomes/IncomeSourceController.java
@@ -9,6 +9,7 @@ import org.globe42.dao.IncomeSourceTypeDao;
 import org.globe42.domain.IncomeSource;
 import org.globe42.domain.IncomeSourceType;
 import org.globe42.web.exception.BadRequestException;
+import org.globe42.web.exception.ErrorCode;
 import org.globe42.web.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -55,7 +56,7 @@ public class IncomeSourceController {
     @ResponseStatus(HttpStatus.CREATED)
     public IncomeSourceDTO create(@Validated @RequestBody IncomeSourceCommandDTO command) {
         if (incomeSourceDao.existsByName(command.getName())) {
-            throw new BadRequestException("This name is already used by another income source");
+            throw new BadRequestException(ErrorCode.INCOME_SOURCE_NAME_ALREADY_EXISTS);
         }
 
         IncomeSource source = new IncomeSource();
@@ -69,7 +70,7 @@ public class IncomeSourceController {
         IncomeSource source = incomeSourceDao.findById(sourceId).orElseThrow(NotFoundException::new);
 
         incomeSourceDao.findByName(command.getName()).filter(other -> !other.getId().equals(sourceId)).ifPresent(other -> {
-            throw new BadRequestException("This name is already used by another income source");
+            throw new BadRequestException(ErrorCode.INCOME_SOURCE_NAME_ALREADY_EXISTS);
         });
 
         copyCommandToSource(command, source);

--- a/backend/src/main/java/org/globe42/web/incomes/IncomeSourceTypeController.java
+++ b/backend/src/main/java/org/globe42/web/incomes/IncomeSourceTypeController.java
@@ -7,6 +7,7 @@ import javax.transaction.Transactional;
 import org.globe42.dao.IncomeSourceTypeDao;
 import org.globe42.domain.IncomeSourceType;
 import org.globe42.web.exception.BadRequestException;
+import org.globe42.web.exception.ErrorCode;
 import org.globe42.web.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -43,7 +44,7 @@ public class IncomeSourceTypeController {
     @ResponseStatus(HttpStatus.CREATED)
     public IncomeSourceTypeDTO create(@Validated @RequestBody IncomeSourceTypeCommandDTO command) {
         if (incomeSourceTypeDao.existsByType(command.getType())) {
-            throw new BadRequestException("This type is already used by another income source type");
+            throw new BadRequestException(ErrorCode.INCOME_SOURCE_TYPE_NAME_ALREADY_EXISTS);
         }
 
         IncomeSourceType type = new IncomeSourceType();
@@ -57,7 +58,7 @@ public class IncomeSourceTypeController {
         IncomeSourceType type = incomeSourceTypeDao.findById(typeId).orElseThrow(NotFoundException::new);
 
         incomeSourceTypeDao.findByType(command.getType()).filter(other -> !other.getId().equals(typeId)).ifPresent(other -> {
-            throw new BadRequestException("This type is already used by another income source type");
+            throw new BadRequestException(ErrorCode.INCOME_SOURCE_TYPE_NAME_ALREADY_EXISTS);
         });
 
         copyCommandToType(command, type);

--- a/backend/src/main/java/org/globe42/web/users/UserController.java
+++ b/backend/src/main/java/org/globe42/web/users/UserController.java
@@ -7,6 +7,7 @@ import javax.transaction.Transactional;
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
 import org.globe42.web.exception.BadRequestException;
+import org.globe42.web.exception.ErrorCode;
 import org.globe42.web.exception.NotFoundException;
 import org.globe42.web.security.AdminOnly;
 import org.globe42.web.security.CurrentUser;
@@ -77,7 +78,7 @@ public class UserController {
     @AdminOnly
     public UserWithPasswordDTO create(@Validated @RequestBody UserCommandDTO command) {
         if (userDao.existsByLogin(command.getLogin())) {
-            throw new BadRequestException("This login is already used by another user");
+            throw new BadRequestException(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
         }
 
         User user = new User();
@@ -98,7 +99,7 @@ public class UserController {
         User user = userDao.findById(userId).orElseThrow(() -> new NotFoundException("No user with ID " + userId));
 
         userDao.findByLogin(command.getLogin()).filter(other -> !other.getId().equals(userId)).ifPresent(other -> {
-            throw new BadRequestException("This login is already used by another user");
+            throw new BadRequestException(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
         });
 
         copyCommandToUser(command, user);

--- a/backend/src/test/java/org/globe42/web/exception/BadRequestExceptionTest.java
+++ b/backend/src/test/java/org/globe42/web/exception/BadRequestExceptionTest.java
@@ -1,0 +1,50 @@
+package org.globe42.web.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link BadRequestException}
+ * @author JB Nizet
+ */
+public class BadRequestExceptionTest {
+    @Test
+    public void shouldCreateWithMessage() {
+        BadRequestException e = new BadRequestException("foo");
+
+        assertThat(e.getError()).isNull();
+        assertThat(e.getMessage()).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldCreateWithErrorCode() {
+        BadRequestException e = new BadRequestException(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
+
+        assertThat(e.getMessage()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS.toString());
+        assertThat(e.getError().getCode()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
+        assertThat(e.getError().getParameters()).isEmpty();
+    }
+
+    @Test
+    public void shouldCreateWithErrorCodeAndParameter() {
+        BadRequestException e = new BadRequestException(ErrorCode.USER_LOGIN_ALREADY_EXISTS, "foo", "bar");
+
+        assertThat(e.getMessage()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS.toString());
+        assertThat(e.getError().getCode()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
+        assertThat(e.getError().getParameters()).containsOnly(entry("foo", "bar"));
+    }
+
+    @Test
+    public void shouldCreateWithFunctionalError() {
+        BadRequestException e = new BadRequestException(new FunctionalError(ErrorCode.USER_LOGIN_ALREADY_EXISTS,
+                                                                            Collections.singletonMap("foo", "bar")));
+
+        assertThat(e.getMessage()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS.toString());
+        assertThat(e.getError().getCode()).isEqualTo(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
+        assertThat(e.getError().getParameters()).containsOnly(entry("foo", "bar"));
+    }
+}

--- a/backend/src/test/java/org/globe42/web/exception/ExceptionConfigTest.java
+++ b/backend/src/test/java/org/globe42/web/exception/ExceptionConfigTest.java
@@ -1,0 +1,64 @@
+package org.globe42.web.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorAttributes;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * Unit tests for {@link ExceptionConfig}
+ * @author JB Nizet
+ */
+public class ExceptionConfigTest {
+    @Test
+    public void shouldIncludeFunctionalError() {
+        ErrorAttributes result = new ExceptionConfig().errorAttributes();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        WebRequest webRequest = new ServletWebRequest(request);
+
+        result = spy(result);
+        BadRequestException exception = new BadRequestException(ErrorCode.USER_LOGIN_ALREADY_EXISTS);
+        doReturn(exception).when(result).getError(webRequest);
+
+        Map<String, Object> errorAttributes = result.getErrorAttributes(webRequest, false);
+
+        assertThat(errorAttributes.get("functionalError")).isEqualTo(exception.getError());
+    }
+
+    @Test
+    public void shouldNotIncludeFunctionalErrorIfNotPresent() {
+        ErrorAttributes result = new ExceptionConfig().errorAttributes();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        WebRequest webRequest = new ServletWebRequest(request);
+
+        result = spy(result);
+        BadRequestException exception = new BadRequestException("foo");
+        doReturn(exception).when(result).getError(webRequest);
+
+        Map<String, Object> errorAttributes = result.getErrorAttributes(webRequest, false);
+
+        assertThat(errorAttributes.containsKey("functionalError")).isFalse();
+    }
+
+    @Test
+    public void shouldNotIncludeFunctionalErrorIfNotBadRequestException() {
+        ErrorAttributes result = new ExceptionConfig().errorAttributes();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        WebRequest webRequest = new ServletWebRequest(request);
+
+        result = spy(result);
+        IllegalStateException exception = new IllegalStateException("foo");
+        doReturn(exception).when(result).getError(webRequest);
+
+        Map<String, Object> errorAttributes = result.getErrorAttributes(webRequest, false);
+
+        assertThat(errorAttributes.containsKey("functionalError")).isFalse();
+    }
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,5 +1,6 @@
 <gl-menu></gl-menu>
 <div class="container" style="margin-top: 70px;">
+  <gl-error></gl-error>
   <router-outlet></router-outlet>
 </div>
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -48,6 +48,8 @@ import { PersonIncomesComponent } from './person-incomes/person-incomes.componen
 import { ConfirmModalContentComponent } from './confirm-modal-content/confirm-modal-content.component';
 import { ConfirmService } from './confirm.service';
 import { PersonIncomeEditComponent } from './person-income-edit/person-income-edit.component';
+import { ErrorService } from './error.service';
+import { ErrorComponent } from './error/error.component';
 
 @NgModule({
   declarations: [
@@ -73,7 +75,8 @@ import { PersonIncomeEditComponent } from './person-income-edit/person-income-ed
     PersonIncomesComponent,
     PersonLayoutComponent,
     ConfirmModalContentComponent,
-    PersonIncomeEditComponent
+    PersonIncomeEditComponent,
+    ErrorComponent
   ],
   entryComponents: [
     ConfirmModalContentComponent
@@ -106,9 +109,15 @@ import { PersonIncomeEditComponent } from './person-income-edit/person-income-ed
     IncomesResolverService,
     UserResolverService,
     JwtInterceptorService,
+    ErrorService,
     {
       provide: HTTP_INTERCEPTORS,
       useExisting: JwtInterceptorService,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useExisting: ErrorService,
       multi: true
     },
     {

--- a/frontend/src/app/error.service.spec.ts
+++ b/frontend/src/app/error.service.spec.ts
@@ -1,0 +1,155 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorService } from './error.service';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { FunctionalErrorModel, TechnicalErrorModel } from './models/error.model';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+
+// should rather use the HttpClientTestingModule, which would allow to make _handleError private,
+// but the issue https://github.com/angular/angular/issues/18181 prevents doing that
+describe('ErrorInterceptorService', () => {
+
+  let service: ErrorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ ErrorService ]
+    });
+
+    service = TestBed.get(ErrorService);
+  });
+
+  it('should emit technical error when error is not an HTTP response', () => {
+    let error: TechnicalErrorModel;
+    service.technicalErrors.subscribe(err => {
+      error = err;
+    });
+
+    service._handleError(new HttpErrorResponse({ error: new Error('not good') }));
+
+    expect(error.status).toBeUndefined();
+    expect(error.message).toBe('not good');
+  });
+
+  it('should emit technical error when error is an HTTP response with no JSON body', () => {
+    let error: TechnicalErrorModel;
+    service.technicalErrors.subscribe(err => {
+      error = err;
+    });
+
+    service._handleError(new HttpErrorResponse({ status: 500, statusText: 'Server Error' }));
+
+    expect(error.status).toBe(500);
+    expect(error.message).toBe('Http failure response for (unknown url): 500 Server Error');
+  });
+
+  it('should emit technical error when error is an HTTP response with a spring boot json body', () => {
+    let error: TechnicalErrorModel;
+    service.technicalErrors.subscribe(err => {
+      error = err;
+    });
+
+    service._handleError(new HttpErrorResponse({ status: 500, statusText: 'Server Error', error: { message: 'Not good' } }));
+
+    expect(error.status).toBe(500);
+    expect(error.message).toBe('Not good');
+  });
+
+  it('should not emit anything when error is an HTTP response with a json body having a functional error', () => {
+    let functionalError: FunctionalErrorModel;
+    let technicalError: TechnicalErrorModel;
+
+    service.functionalErrors.subscribe(err => {
+      functionalError = err;
+    });
+    service.technicalErrors.subscribe(err => {
+      technicalError = err;
+    });
+
+    service._handleError(new HttpErrorResponse({
+      status: 400,
+      statusText: 'Server Error',
+      error: {
+        message: 'Not good',
+        functionalError: {
+          code: 'ERROR_CODE',
+          parameters: { foo: 'bar' }
+        }
+      }
+    }));
+
+    expect(functionalError).toBeUndefined();
+    expect(technicalError).toBeUndefined();
+  });
+
+  it('should not emit anything when error is an HTTP response with a 401 status for the authentication resource', () => {
+    let functionalError: FunctionalErrorModel;
+    let technicalError: TechnicalErrorModel;
+
+    service.functionalErrors.subscribe(err => {
+      functionalError = err;
+    });
+    service.technicalErrors.subscribe(err => {
+      technicalError = err;
+    });
+
+    service._handleError(new HttpErrorResponse({
+      status: 401,
+      statusText: 'Unauthorized',
+      url: 'http://localhost/api/authentication'
+    }));
+
+    expect(functionalError).toBeUndefined();
+    expect(technicalError).toBeUndefined();
+  });
+
+  it('should emit a functional error when the handler is invoked with a functional error response', () => {
+    let error: FunctionalErrorModel;
+
+    service.functionalErrors.subscribe(err => {
+      error = err;
+    });
+
+    service.functionalErrorHandler()(new HttpErrorResponse({
+      status: 400,
+      statusText: 'Server Error',
+      error: {
+        message: 'Not good',
+        functionalError: {
+          code: 'ERROR_CODE',
+          parameters: { foo: 'bar' }
+        }
+      }
+    }));
+
+    expect(error.code).toBe('ERROR_CODE');
+    expect(error.parameters).toEqual({ foo: 'bar' });
+  });
+
+  it('should intercept', () => {
+    // we expect this will be populated when the observable returned by the next handler throws an HttpErrorResponse
+    let error: TechnicalErrorModel;
+    service.technicalErrors.subscribe(err => {
+      error = err;
+    });
+
+    // create a fake next handle that throws an HttpErrorResponse when we want to
+    const errorSubject = new Subject<HttpEvent<any>>();
+    const next: HttpHandler = {
+      handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
+        return errorSubject;
+      }
+    };
+
+    // call intercept() on our service
+    service.intercept(null, next).subscribe(null, () => {});
+
+    // make the next handler throw
+    errorSubject.error(new HttpErrorResponse({ error: new Error('not good') }));
+
+    // check that the service indeed emitted a technical error
+    expect(error.status).toBeUndefined();
+    expect(error.message).toBe('not good');
+  });
+});

--- a/frontend/src/app/error.service.ts
+++ b/frontend/src/app/error.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { FunctionalErrorModel, TechnicalErrorModel } from './models/error.model';
+
+/**
+ * Service which acts as an HTTP interceptor, in order to emit HTTP errors (which are then consumed by the
+ * error component).
+ *
+ * It separates errors in two kinds: technical and functional errors. Functional errors are expected errors,
+ * thrown by the backend using a BadRequestException status code 400) with a JSON body containing a functionalError
+ * property. All the other errors are technical.
+ *
+ * Except for 401 errors returned from the /api/authenticate resource, all the other technical errors are emitted by
+ * the interceptor.
+ *
+ * The functional errors are not emitted by the interceptor. Instead, they're supposed to be handled by the component,
+ * the way they want to. If the components just want to display the error in the error component, they can simply pass
+ * the function returned by the functionalErrorHandler method in their subscribe/catch operator:
+ *
+ *   someService.subscribe(..., this.errorService.functionalErrorHandler()
+ *
+ * This functional error handler will check that the error is indeed functional, and if it is, it will emit it
+ * so that the error component can display it in the generic error location.
+ */
+@Injectable()
+export class ErrorService implements HttpInterceptor {
+
+  /**
+   * Observable that the error component subscribes to in order to receive functional errors emitted by the
+   * functionalErrorHandler callback functions returned by this service, and used by the components.
+   */
+  functionalErrors = new Subject<FunctionalErrorModel>();
+
+  /**
+   * Observable that the error component subscribes to in order to receive technical errors emitted by this interceptor
+   */
+  technicalErrors = new Subject<TechnicalErrorModel>();
+
+  constructor() { }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).do(null, error => this._handleError(error));
+  }
+
+  // visible for testing
+  _handleError(error: HttpErrorResponse) {
+    if (error.error instanceof Error) {
+      // the error is not a HTTP response from the backend
+      this.technicalErrors.next({ message: error.error.message });
+    }
+    else {
+      // the error is a response from the backend
+      // if the error is a functional error, ignore it: it should be handled by the component.
+      // if the error status is 401, ignore it: the component should handle it
+      if (!this.isFunctional(error) && !this.isExpectedAuthenticationError(error)) {
+        const body = error.error;
+
+        if (body && body.message) {
+          // the error is a spring boot error
+          this.technicalErrors.next({status: error.status, message: body.message});
+        }
+        else {
+          // the error is a an HTTP response, but which doesn't contain a spring boot payload
+          this.technicalErrors.next({status: error.status, message: error.message});
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns a callback function that can be used by components to react to functional errors and emit them so that
+   * the error component displays them in the usual location.
+   */
+  functionalErrorHandler() : (err: HttpErrorResponse) => void {
+    return (err: HttpErrorResponse) => {
+      if (this.isFunctional(err)) {
+        this.functionalErrors.next(err.error.functionalError);
+      }
+    }
+  }
+
+  private isFunctional(error: HttpErrorResponse) {
+    const body = error.error;
+    return error.status === 400 && body && body.functionalError;
+  }
+
+  private isExpectedAuthenticationError(error: HttpErrorResponse) {
+    return error.status === 401 && error.url.endsWith('/api/authentication');
+  }
+}

--- a/frontend/src/app/error/error.component.html
+++ b/frontend/src/app/error/error.component.html
@@ -1,0 +1,10 @@
+<ngb-alert class="error-alert" type="danger" *ngIf="error" (close)="error = null;">
+  <ng-container *ngIf="error.technical">
+    Une erreur technique inattendue s'est produite. Essayez de recharger la page.
+    <br/>
+    <small>{{ error.status ? error.status + ' - ' + error.message : error.message }}</small>
+  </ng-container>
+  <ng-container *ngIf="!error.technical">
+    {{ error.message }}
+  </ng-container>
+</ngb-alert>

--- a/frontend/src/app/error/error.component.scss
+++ b/frontend/src/app/error/error.component.scss
@@ -1,0 +1,8 @@
+.error-alert {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  width: 400px;
+  max-width: 90vw;
+  z-index: 1;
+}

--- a/frontend/src/app/error/error.component.spec.ts
+++ b/frontend/src/app/error/error.component.spec.ts
@@ -1,0 +1,140 @@
+import { async, TestBed } from '@angular/core/testing';
+
+import { ErrorComponent } from './error.component';
+import { AppModule } from '../app.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ErrorService } from '../error.service';
+import { NavigationEnd, NavigationStart, Router } from '@angular/router';
+import { Subject } from 'rxjs/Subject';
+
+describe('ErrorComponent', () => {
+
+  let errorService: ErrorService;
+  let fakeRouter : {
+    events: Subject<any>
+  };
+
+  beforeEach(async(() => {
+    fakeRouter = { events: new Subject<any>() };
+
+    TestBed.configureTestingModule({
+      imports: [AppModule, RouterTestingModule],
+      providers: [ { provide: Router, useValue: fakeRouter }]
+    });
+
+    errorService = TestBed.get(ErrorService);
+  }));
+
+  it('should react to technical errors', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeFalsy();
+
+    errorService.technicalErrors.next({ status: 500, message: 'Server error' });
+
+    expect(component.error).toEqual({ status: 500, technical: true, message: 'Server error' });
+  });
+
+  it('should react to functional errors without parameters', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeFalsy();
+
+    errorService.functionalErrors.next({ code: 'USER_LOGIN_ALREADY_EXISTS' });
+
+    expect(component.error).toEqual({ technical: false, message: 'Un utilisateur ayant le même identifiant existe déjà.' });
+  });
+
+  it('should react to functional errors with parameters', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeFalsy();
+
+    errorService.functionalErrors.next({ code: '__TEST__', parameters: {login: 'JB'} });
+
+    expect(component.error).toEqual({ technical: false, message: 'Hello JB' });
+  });
+
+  it('should react to functional errors with unknown code', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeFalsy();
+
+    errorService.functionalErrors.next({ code: 'UNKNOWN' });
+
+    expect(component.error).toEqual({ technical: false, message: 'UNKNOWN' });
+  });
+
+  it('should react to navigation end events', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+    const router = TestBed.get(Router);
+
+    component.error = { technical: false, message: 'Hello JB' };
+
+    fakeRouter.events.next(new NavigationStart(1, 'url'));
+    fixture.detectChanges();
+
+    expect(component.error).not.toBeNull();
+
+    fakeRouter.events.next(new NavigationEnd(1, 'url', ''));
+    fixture.detectChanges();
+
+    expect(component.error).toBeNull();
+  });
+
+  it('should display a technical error with status', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+    const element = fixture.nativeElement;
+
+    fixture.detectChanges();
+
+    expect(element.querySelector('ngb-alert')).toBeNull();
+
+    component.error = { status: 500, technical: true, message: 'Server error' };
+    fixture.detectChanges();
+
+    expect(element.querySelector('ngb-alert').textContent).toContain('Une erreur technique inattendue s\'est produite. Essayez de recharger la page.');
+    expect(element.querySelector('ngb-alert small').textContent).toContain('500 - Server error');
+
+    component.error = null;
+    fixture.detectChanges();
+
+    expect(element.querySelector('ngb-alert')).toBeNull();
+  });
+
+  it('should display a technical error without status', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+    const element = fixture.nativeElement;
+
+    component.error = { technical: true, message: 'Server error' };
+    fixture.detectChanges();
+
+    expect(element.querySelector('ngb-alert small').textContent).toContain('Server error');
+  });
+
+  it('should display a functional error', () => {
+    const fixture = TestBed.createComponent(ErrorComponent);
+    const component = fixture.componentInstance;
+    const element = fixture.nativeElement;
+
+    component.error = { technical: false, message: 'Booo!' };
+    fixture.detectChanges();
+
+    expect(element.querySelector('ngb-alert').textContent).toContain('Booo!');
+  });
+});

--- a/frontend/src/app/error/error.component.ts
+++ b/frontend/src/app/error/error.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { ErrorService } from '../error.service';
+import { NavigationEnd, Router } from '@angular/router';
+import { ERRORS, FunctionalErrorModel } from '../models/error.model';
+import { interpolate } from '../utils';
+import 'rxjs/add/operator/filter';
+
+@Component({
+  selector: 'gl-error',
+  templateUrl: './error.component.html',
+  styleUrls: ['./error.component.scss']
+})
+export class ErrorComponent implements OnInit {
+
+  error: {
+    message: string,
+    technical: boolean,
+    status?: number
+  };
+
+  constructor(private interceptor: ErrorService, private router: Router) { }
+
+  ngOnInit() {
+    this.interceptor.functionalErrors.subscribe(
+      err => this.error = { message: this.toMessage(err) || err.code, technical: false });
+    this.interceptor.technicalErrors.subscribe(
+      err => this.error = { message: err.message, technical: true, status: err.status });
+
+    this.router.events
+      .filter(event => event instanceof NavigationEnd)
+      .subscribe(() => this.error = null);
+  }
+
+  private toMessage(error: FunctionalErrorModel) {
+    const template = ERRORS[error.code];
+    if (!template) {
+      return error.code;
+    }
+    if (error.parameters) {
+      return interpolate(template, error.parameters);
+    }
+    return template;
+  }
+}

--- a/frontend/src/app/income-source-edit/income-source-edit.component.ts
+++ b/frontend/src/app/income-source-edit/income-source-edit.component.ts
@@ -5,6 +5,7 @@ import { IncomeSourceCommand } from '../models/income-source.command';
 import { IncomeSourceModel } from '../models/income-source.model';
 import { IncomeSourceTypeModel } from '../models/income-source-type.model';
 import { IncomeSourceService } from '../income-source.service';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'gl-income-source-edit',
@@ -18,11 +19,14 @@ export class IncomeSourceEditComponent implements OnInit {
   incomeSourceTypes: Array<IncomeSourceTypeModel>;
   incomeSource: IncomeSourceCommand;
 
-  constructor(private route: ActivatedRoute, private incomeSourceService: IncomeSourceService, private router: Router) { }
+  constructor(private route: ActivatedRoute,
+              private incomeSourceService: IncomeSourceService,
+              private router: Router,
+              private errorService: ErrorService) { }
 
   ngOnInit() {
-    this.incomeSourceTypes = this.route.snapshot.data['incomeSourceTypes'];
-    sortBy(this.incomeSourceTypes, type => type.type);
+    this.incomeSourceTypes =
+      sortBy<IncomeSourceTypeModel>(this.route.snapshot.data['incomeSourceTypes'], type => type.type);
 
     this.editedIncomeSource = this.route.snapshot.data['incomeSource'];
 
@@ -50,6 +54,8 @@ export class IncomeSourceEditComponent implements OnInit {
     else {
       action = this.incomeSourceService.create(this.incomeSource);
     }
-    action.subscribe(() => this.router.navigate(['/income-sources']));
+    action.subscribe(
+      () => this.router.navigate(['/income-sources']),
+      this.errorService.functionalErrorHandler());
   }
 }

--- a/frontend/src/app/income-type-edit/income-type-edit.component.html
+++ b/frontend/src/app/income-type-edit/income-type-edit.component.html
@@ -3,11 +3,6 @@
   <ng-container *ngIf="!editedIncomeType">Nouveau type de revenu</ng-container>
 </h1>
 
-<div class="alert alert-danger" *ngIf="actionFailed">
-  <button type="button" class="close" aria-label="Close" (click)="actionFailed = false;"><span aria-hidden="true">&#215;</span></button>
-  Erreur à la sauvegarde du type de revenu.
-</div>
-
 <form (ngSubmit)="save()" #typeForm="ngForm">
   <div class="form-group row">
     <label for="type" class="col-sm-2 col-form-label">Type</label>

--- a/frontend/src/app/income-type-edit/income-type-edit.component.ts
+++ b/frontend/src/app/income-type-edit/income-type-edit.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { IncomeSourceTypeCommand } from '../models/income-source-type.command';
 import { IncomeSourceTypeModel } from '../models/income-source-type.model';
 import { IncomeSourceTypeService } from '../income-source-type.service';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'gl-income-type-edit',
@@ -14,9 +15,11 @@ export class IncomeTypeEditComponent implements OnInit {
 
   editedIncomeType: IncomeSourceTypeModel;
   incomeType: IncomeSourceTypeCommand;
-  actionFailed = false;
 
-  constructor(private route: ActivatedRoute, private router: Router, private incomeSourceTypeService: IncomeSourceTypeService) { }
+  constructor(private route: ActivatedRoute,
+              private router: Router,
+              private incomeSourceTypeService: IncomeSourceTypeService,
+              private errorService: ErrorService) { }
 
   ngOnInit() {
     this.editedIncomeType = this.route.snapshot.data['incomeType'];
@@ -32,7 +35,7 @@ export class IncomeTypeEditComponent implements OnInit {
     }
     action.subscribe(
       () => this.router.navigateByUrl('/income-types'),
-      error => this.actionFailed = true
+      this.errorService.functionalErrorHandler()
     );
   }
 

--- a/frontend/src/app/jwt-interceptor.service.spec.ts
+++ b/frontend/src/app/jwt-interceptor.service.spec.ts
@@ -1,60 +1,56 @@
 import { JwtInterceptorService } from './jwt-interceptor.service';
-import { HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-
-const fakeObservable = {} as Observable<HttpEvent<any>>;
-
-class FakeHttpHandler extends HttpHandler {
-  handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
-    return fakeObservable;
-  }
-}
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('JwtInterceptorService', () => {
+
+  let http: HttpTestingController;
+  let httpClient: HttpClient;
+  let service: JwtInterceptorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        JwtInterceptorService,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useExisting: JwtInterceptorService,
+          multi: true
+        }
+      ],
+      imports: [ HttpClientTestingModule ]
+    });
+
+    http = TestBed.get(HttpTestingController);
+    httpClient = TestBed.get(HttpClient);
+    service = TestBed.get(JwtInterceptorService);
+  });
+
   it('should not add token if no token', () => {
-    const interceptor = new JwtInterceptorService();
-    const req = new HttpRequest('GET', '/users');
+    httpClient.get('/test').subscribe();
+    const testRequest = http.expectOne('/test');
+    testRequest.flush(null);
 
-    const handler = new FakeHttpHandler();
-    spyOn(handler, 'handle').and.callThrough();
-
-    const result = interceptor.intercept(req, handler);
-
-    expect(handler.handle).toHaveBeenCalledWith(req);
-    expect(result).toBe(fakeObservable);
+    expect(testRequest.request.headers.get('Authorization')).toBeNull();
   });
 
   it('should not add token if token present but request to external resource', () => {
-    const interceptor = new JwtInterceptorService();
-    interceptor.token = 'secret';
-    const req = new HttpRequest('GET', 'http://vicopo.selfbuild.fr/cherche/SAINT');
+    service.token = 'secret';
+    const url = 'http://vicopo.selfbuild.fr/cherche/SAINT';
+    httpClient.get(url).subscribe();
+    const testRequest = http.expectOne(url);
+    testRequest.flush(null);
 
-    const handler = new FakeHttpHandler();
-    spyOn(handler, 'handle').and.callThrough();
-
-    const result = interceptor.intercept(req, handler);
-
-    expect(handler.handle).toHaveBeenCalledWith(req);
-    expect(result).toBe(fakeObservable);
+    expect(testRequest.request.headers.get('Authorization')).toBeNull();
   });
 
   it('should add token if token present and request to internal resource', () => {
-    const interceptor = new JwtInterceptorService();
-    interceptor.token = 'secret';
-    const req = new HttpRequest('GET', '/users');
+    service.token = 'secret';
+    httpClient.get('/test').subscribe();
+    const testRequest = http.expectOne('/test');
+    testRequest.flush(null);
 
-    const handler = new FakeHttpHandler();
-    spyOn(handler, 'handle').and.callThrough();
-
-    const result = interceptor.intercept(req, handler);
-
-    expect(handler.handle).toHaveBeenCalled();
-    const actualRequest: HttpRequest<any> = (handler.handle as jasmine.Spy).calls.argsFor(0)[0];
-
-    expect(actualRequest.method).toBe('GET');
-    expect(actualRequest.url).toBe('/users');
-    expect(actualRequest.headers.get('Authorization')).toBe('Bearer secret');
-
-    expect(result).toBe(fakeObservable);
+    expect(testRequest.request.headers.get('Authorization')).toBe('Bearer secret');
   });
 });

--- a/frontend/src/app/models/error.model.ts
+++ b/frontend/src/app/models/error.model.ts
@@ -1,0 +1,17 @@
+import { HttpErrorResponse } from '@angular/common/http';
+export interface FunctionalErrorModel {
+  code: string;
+  parameters?: { [key: string]: any };
+}
+
+export interface TechnicalErrorModel {
+  status?: number;
+  message: string;
+}
+
+export const ERRORS = Object.freeze({
+  USER_LOGIN_ALREADY_EXISTS: 'Un utilisateur ayant le même identifiant existe déjà.',
+  INCOME_SOURCE_TYPE_NAME_ALREADY_EXISTS: 'Un type de revenu du même nom existe déjà.',
+  INCOME_SOURCE_NAME_ALREADY_EXISTS: 'Une source de revenu du même nom existe déjà.',
+  __TEST__: 'Hello ${login}'
+});

--- a/frontend/src/app/person-income-edit/person-income-edit.component.ts
+++ b/frontend/src/app/person-income-edit/person-income-edit.component.ts
@@ -27,8 +27,7 @@ export class PersonIncomeEditComponent implements OnInit {
 
   ngOnInit() {
     this.person = this.route.snapshot.data['person'];
-    this.incomeSources = this.route.snapshot.data['incomeSources'];
-    sortBy(this.incomeSources, source => source.name);
+    this.incomeSources = sortBy<IncomeSourceModel>(this.route.snapshot.data['incomeSources'], source => source.name);
     this.income = {
       source: null,
       monthlyAmount: null

--- a/frontend/src/app/user-edit/user-edit.component.ts
+++ b/frontend/src/app/user-edit/user-edit.component.ts
@@ -4,6 +4,7 @@ import { UserCommand } from '../models/user.command';
 import { UserWithPasswordModel } from '../models/user-with-password.model';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UserModel } from '../models/user.model';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'gl-user-edit',
@@ -19,7 +20,8 @@ export class UserEditComponent implements OnInit {
 
   constructor(private userService: UserService,
               private route: ActivatedRoute,
-              private router: Router) { }
+              private router: Router,
+              private errorService: ErrorService) { }
 
   ngOnInit() {
     this.editedUser = this.route.snapshot.data['user'];
@@ -31,11 +33,13 @@ export class UserEditComponent implements OnInit {
 
   save() {
     if (this.editedUser) {
-      this.userService.update(this.editedUser.id, this.user)
-        .subscribe(() => this.router.navigate(['/users']));
+      this.userService.update(this.editedUser.id, this.user).subscribe(
+        () => this.router.navigate(['/users']),
+        this.errorService.functionalErrorHandler());
     } else {
-      this.userService.create(this.user)
-        .subscribe(createdUser => this.createdUser = createdUser);
+      this.userService.create(this.user).subscribe(
+        createdUser => this.createdUser = createdUser,
+        this.errorService.functionalErrorHandler());
     }
   }
 }

--- a/frontend/src/app/users/users.component.ts
+++ b/frontend/src/app/users/users.component.ts
@@ -15,7 +15,6 @@ export class UsersComponent implements OnInit {
   constructor(private route: ActivatedRoute) { }
 
   ngOnInit() {
-    this.users = this.route.snapshot.data['users'];
-    sortBy(this.users, u => u.login);
+    this.users = sortBy<UserModel>(this.route.snapshot.data['users'], u => u.login);
   }
 }

--- a/frontend/src/app/utils.spec.ts
+++ b/frontend/src/app/utils.spec.ts
@@ -1,4 +1,4 @@
-import { sortBy } from './utils';
+import { sortBy, interpolate } from './utils';
 
 describe('utils', () => {
   it('should sort by', () => {
@@ -10,7 +10,15 @@ describe('utils', () => {
       { foo: 'b' }
     ];
 
-    sortBy(array, o => o.foo);
-    expect(array.map(o => o.foo)).toEqual(['a', 'a', 'b', 'b', 'c']);
+    const result = sortBy(array, o => o.foo);
+    expect(result.map(o => o.foo)).toEqual(['a', 'a', 'b', 'b', 'c']);
+    expect(result).not.toBe(array);
+  });
+
+  it('should interpolate', () => {
+    const template = 'Hello ${w}, the ${w} is ${score}/${total} today';
+    expect(interpolate(template, { w: 'world', score: 9, total: 10 })).toBe(
+      'Hello world, the world is 9/10 today'
+    );
   });
 });

--- a/frontend/src/app/utils.ts
+++ b/frontend/src/app/utils.ts
@@ -1,5 +1,12 @@
-export function sortBy<T>(array: Array<T>, extractor: (T) => any) {
-  array.sort((e1, e2) => {
+/**
+ * Creates a sorted copy of an array, by extracting a value from each element using the given extractor,
+ * and comparing the values.
+ *
+ * Usages of this method could be replaced by Lodash's sortBy method
+ */
+export function sortBy<T>(array: Array<T>, extractor: (T) => any): Array<T> {
+  const result = array.slice();
+  result.sort((e1, e2) => {
     const v1 = extractor(e1);
     const v2 = extractor(e2);
     if (v1 < v2) {
@@ -10,4 +17,29 @@ export function sortBy<T>(array: Array<T>, extractor: (T) => any) {
     }
     return 0;
   });
+  return result;
+}
+
+/**
+ * Takes a string containing placeholders such as ${foo}, and replaces them by their value in the given
+ * parameters. Beware: no expression supported, no space in curly braces.
+ *
+ * So interpolate('hello ${name}', { name: 'JB' }) returns "hello JB".
+ *
+ * This function is only used (currently) to generate functional error messages from code and parameters
+ * coming from the backend.
+ */
+export function interpolate(template: string, parameters: {[key: string]: any}): string {
+  // ugly loop because JS doesn't have a Regexp.quote() method, nor a replaceAll method. replace is supposed to replace
+  // all, but it does not.
+  let result = template;
+  Object.keys(parameters).forEach(key => {
+    const searchValue = '${' + key + '}';
+    const replaceValue = `${parameters[key]}`;
+    do {
+      result = result.replace(searchValue, replaceValue);
+    }
+    while (result.indexOf(searchValue) >= 0)
+  });
+  return result;
 }


### PR DESCRIPTION
This is an exploratory WIP to test what I think we should do to fix #47.

Please tell me what you think about it.

In fact I think I would prefer to let the interceptor handle all the errors, even the functional ones, but in some use cases, the default behavior would not be adequate (that could also be true with technical errors, BTW). It would really be nice if https://github.com/angular/angular/issues/18155 was accepted and fixed.

In the meantime, I'm sure we could find a workaround solution.

The various kinds of errors can be tested the following way:
 - stop the ng server, and try navigating: technical error without a http response
 - stop the backend server: technical error response sent by the ng server
 - try to create a user with a login that already exists: functional error