### PR TITLE
Feat/address search api

### DIFF
--- a/backend/src/main/java/org/globe42/dao/PostalCityDao.java
+++ b/backend/src/main/java/org/globe42/dao/PostalCityDao.java
@@ -1,0 +1,12 @@
+package org.globe42.dao;
+
+import org.globe42.domain.PostalCity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * DAO for {@link org.globe42.domain.PostalCity}
+ * @author JB Nizet
+ */
+public interface PostalCityDao extends JpaRepository<PostalCity, Long>, PostalCityDaoCustom {
+
+}

--- a/backend/src/main/java/org/globe42/dao/PostalCityDaoCustom.java
+++ b/backend/src/main/java/org/globe42/dao/PostalCityDaoCustom.java
@@ -1,0 +1,28 @@
+package org.globe42.dao;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.globe42.domain.PostalCity;
+
+/**
+ * Custom methods of {@link PostalCityDao}
+ * @author JB Nizet
+ */
+public interface PostalCityDaoCustom {
+
+    /**
+     * Inserts all the given cities in an efficient way
+     */
+    void saveAllEfficiently(Collection<PostalCity> cities);
+
+    /**
+     * Finds the N first cities whose postal code starts with the given value
+     */
+    List<PostalCity> findByPostalCode(String search, int limit);
+
+    /**
+     * Finds the N first cities whose name start with the given value, after sanitization
+     */
+    List<PostalCity> findByCity(String search, int limit);
+}

--- a/backend/src/main/java/org/globe42/dao/PostalCityDaoImpl.java
+++ b/backend/src/main/java/org/globe42/dao/PostalCityDaoImpl.java
@@ -1,0 +1,81 @@
+package org.globe42.dao;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+
+import org.globe42.domain.PostalCity;
+
+/**
+ * Implementation of custop methods of {@link PostalCityDao}
+ * @author JB Nizet
+ */
+public class PostalCityDaoImpl implements PostalCityDaoCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public void saveAllEfficiently(Collection<PostalCity> cities) {
+        int counter = 0;
+        for (PostalCity city : cities) {
+            em.persist(city);
+            counter++;
+            if (counter == 50) {
+                counter = 0;
+                em.flush();
+                em.clear();
+            }
+        }
+    }
+
+    @Override
+    public List<PostalCity> findByPostalCode(String search, int limit) {
+        String jpql = "select pc from PostalCity pc where pc.postalCode like :value order by pc.postalCode, pc.city";
+        TypedQuery<PostalCity> query = em.createQuery(jpql, PostalCity.class);
+        return query.setParameter("value", search + "%")
+                    .setMaxResults(limit)
+                    .getResultList();
+    }
+
+    @Override
+    public List<PostalCity> findByCity(String search, int limit) {
+        String jpql = "select pc from PostalCity pc where upper(pc.city) like :value order by pc.city, pc.postalCode";
+        TypedQuery<PostalCity> query = em.createQuery(jpql, PostalCity.class);
+        return query.setParameter("value", sanitizeQuery(search)+ "%")
+                    .setMaxResults(limit)
+                    .getResultList();
+    }
+
+    private String sanitizeQuery(String search) {
+        // Use uppercase
+        String result = search.toUpperCase();
+        // replace dashed and commas with spaces, since thre is none in the data
+        result = result.replace('\'', ' ').replace('-', ' ');
+        // remove accents
+        result = Normalizer.normalize(result, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");
+
+        // strip in parts to make sure there is a single space between parts
+        String[] split = result.split(" ");
+        List<String> parts = new ArrayList<>();
+        for (String part : split) {
+            String trimmedPart = part.trim();
+            if (!trimmedPart.isEmpty()) {
+                // replace SAINT by ST, since that's what the daaset uses
+                if (trimmedPart.equals("SAINT")) {
+                    parts.add("ST");
+                }
+                else {
+                    parts.add(trimmedPart);
+                }
+            }
+        }
+        result = parts.stream().collect(Collectors.joining(" "));
+        return result;
+    }
+}

--- a/backend/src/main/java/org/globe42/domain/PostalCity.java
+++ b/backend/src/main/java/org/globe42/domain/PostalCity.java
@@ -1,0 +1,56 @@
+package org.globe42.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * A city, imported from the official postal code reference at
+ * <a href="https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/">Data Gouv</a>.
+ * @author JB Nizet
+ */
+@Entity
+public class PostalCity {
+    private static final String POSTAL_CITY_GENERATOR = "PostalCityGenerator";
+
+    @Id
+    @SequenceGenerator(name = POSTAL_CITY_GENERATOR, sequenceName = "POSTAL_CITY_SEQ", initialValue = 1000, allocationSize = 1)
+    @GeneratedValue(generator = POSTAL_CITY_GENERATOR)
+    private Long id;
+
+    @NotEmpty
+    private String postalCode;
+
+    /**
+     * The city, which is supposed to be in uppercase
+     */
+    @NotEmpty
+    private String city;
+
+    public PostalCity() {
+    }
+
+    public PostalCity(Long id) {
+        this.id = id;
+    }
+
+    public PostalCity(String postalCode, String city) {
+        this.postalCode = postalCode;
+        this.city = city;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/cities/PostalCityController.java
+++ b/backend/src/main/java/org/globe42/web/cities/PostalCityController.java
@@ -1,0 +1,74 @@
+package org.globe42.web.cities;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+
+import org.globe42.dao.PostalCityDao;
+import org.globe42.domain.PostalCity;
+import org.globe42.web.persons.CityDTO;
+import org.globe42.web.security.AdminOnly;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller used to search for postal cities, and to import them.
+ * @author JB Nizet
+ */
+@RestController
+@RequestMapping(value = "/api/cities")
+@Transactional
+public class PostalCityController {
+
+    public static final int LIMIT = 10;
+
+    private final PostalCityDao postalCityDao;
+    private final PostalCityUploadParser uploadParser;
+
+    public PostalCityController(PostalCityDao postalCityDao, PostalCityUploadParser uploadParser) {
+        this.postalCityDao = postalCityDao;
+        this.uploadParser = uploadParser;
+    }
+
+    @GetMapping(params = "query")
+    public List<CityDTO> search(@RequestParam("query") String query) {
+        List<PostalCity> cities;
+        if (isNumeric(query)) {
+            cities = postalCityDao.findByPostalCode(query, LIMIT);
+        }
+        else {
+            cities = postalCityDao.findByCity(query, LIMIT);
+        }
+
+        return cities.stream().map(CityDTO::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Uploads a file, parses it, removes all the data in the postal_city table, and inserts all the cities
+     * contained in the file.
+     *
+     * You can use the following command line to upload a file and invoke this method:
+     * <pre
+     *   curl -X POST -H "Authorization: Bearer $your-admin-token" $url/api/cities/uploads -T ~/Downloads/laposte_hexasmal.csv
+     * </pre>
+     */
+    @PostMapping("/uploads")
+    @AdminOnly
+    @ResponseStatus(HttpStatus.CREATED)
+    public void upload(@RequestBody byte[] data) {
+        List<PostalCity> cities = uploadParser.parse(data);
+
+        postalCityDao.deleteAll();
+        postalCityDao.saveAllEfficiently(cities);
+    }
+
+    private boolean isNumeric(String query) {
+        return query.chars().allMatch(c -> c >= '0' && c <= '9');
+    }
+}

--- a/backend/src/main/java/org/globe42/web/cities/PostalCityUploadParser.java
+++ b/backend/src/main/java/org/globe42/web/cities/PostalCityUploadParser.java
@@ -1,0 +1,71 @@
+package org.globe42.web.cities;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.globe42.domain.PostalCity;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parser for the CSV file containing postal codes and cities, available at
+ * https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/
+ * @author JB Nizet
+ */
+@Component
+public class PostalCityUploadParser {
+
+    public List<PostalCity> parse(byte[] content) {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(content),
+                                                                         StandardCharsets.UTF_8));
+        return reader.lines()
+                     .skip(1L)
+                     .filter(line -> !line.isEmpty())
+                     .map(this::parseLine)
+                     .distinct()
+                     .map(Line::getPostalCity)
+                     .collect(Collectors.toList());
+    }
+
+    private Line parseLine(String line) {
+        String[] split = line.split(";");
+        return new Line(new PostalCity(split[2], split[1]));
+    }
+
+    /**
+     * Wrapper class allowing to remove duplicates, i.e. lines that have the same postal code and city
+     */
+    private static final class Line {
+        private final PostalCity postalCity;
+
+        public Line(PostalCity postalCity) {
+            this.postalCity = postalCity;
+        }
+
+        public PostalCity getPostalCity() {
+            return postalCity;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Line line = (Line) o;
+            return Objects.equals(this.postalCity.getPostalCode(), line.postalCity.getPostalCode())
+                   && Objects.equals(this.postalCity.getCity(), line.postalCity.getCity());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(postalCity.getPostalCode(), postalCity.getCity());
+        }
+    }
+}

--- a/backend/src/main/java/org/globe42/web/persons/CityDTO.java
+++ b/backend/src/main/java/org/globe42/web/persons/CityDTO.java
@@ -3,6 +3,7 @@ package org.globe42.web.persons;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.globe42.domain.City;
+import org.globe42.domain.PostalCity;
 import org.hibernate.validator.constraints.Length;
 
 /**
@@ -24,6 +25,11 @@ public final class CityDTO {
 
     public CityDTO(City city) {
         this.code = city.getCode();
+        this.city = city.getCity();
+    }
+
+    public CityDTO(PostalCity city) {
+        this.code = city.getPostalCode();
         this.city = city.getCity();
     }
 

--- a/backend/src/main/resources/db/migration/V0009__postal_city.sql
+++ b/backend/src/main/resources/db/migration/V0009__postal_city.sql
@@ -1,0 +1,10 @@
+CREATE TABLE postal_city (
+  id           BIGINT PRIMARY KEY,
+  postal_code  VARCHAR NOT NULL,
+  city         VARCHAR NOT NULL
+);
+
+CREATE SEQUENCE postal_city_seq START WITH 1000;
+
+create INDEX postal_city_idx1 on postal_city(postal_code varchar_pattern_ops);
+create INDEX postal_city_idx2 on postal_city(upper(city) varchar_pattern_ops);

--- a/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
@@ -35,7 +35,8 @@ public abstract class BaseDaoTest {
                                                                "person",
                                                                "family_situation",
                                                                "income_source",
-                                                               "income_source_type");
+                                                               "income_source_type",
+                                                               "postal_city");
 
     private final Operation RESET_ALL_MEDIATION_CODE_SEQUENCES =
         resetAllMediationCodeSequences();

--- a/backend/src/test/java/org/globe42/dao/PostalCityDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/PostalCityDaoTest.java
@@ -1,0 +1,69 @@
+package org.globe42.dao;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.ninja_squad.dbsetup.operation.Insert;
+import com.ninja_squad.dbsetup.operation.Operation;
+import org.globe42.domain.PostalCity;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for {@link PostalCityDao}
+ * @author JB Nizet
+ */
+public class PostalCityDaoTest extends BaseDaoTest {
+    @Autowired
+    private PostalCityDao dao;
+
+    @Before
+    public void prepare() {
+        Operation person =
+            Insert.into("postal_city")
+                  .columns("id", "postal_code", "city")
+                  .values(1L, "01160", "PONT D AIN")
+                  .values(2L, "42000", "ST ETIENNE")
+                  .values(3L, "42100", "ST ETIENNE")
+                  .values(4L, "08310", "ST ETIENNE A ARNES")
+                  .build();
+        dbSetup(person);
+    }
+
+    @Test
+    public void shouldFindByPostalCode() {
+        TRACKER.skipNextLaunch();
+        List<PostalCity> result = dao.findByPostalCode("42", 10);
+        assertThat(result).extracting(PostalCity::getId).containsExactly(2L, 3L);
+
+        result = dao.findByPostalCode("0", 1);
+        assertThat(result).extracting(PostalCity::getId).containsExactly(1L);
+    }
+
+    @Test
+    public void shouldFindByCity() {
+        TRACKER.skipNextLaunch();
+        List<PostalCity> result = dao.findByCity("Saint   étienne", 10);
+        assertThat(result).extracting(PostalCity::getId).containsExactly(2L, 3L, 4L);
+
+        result = dao.findByCity("Pont d'ain", 10);
+        assertThat(result).extracting(PostalCity::getId).containsExactly(1L);
+
+        result = dao.findByCity("Saint   étienne", 1);
+        assertThat(result).extracting(PostalCity::getId).containsExactly(2L);
+    }
+
+    @Test
+    public void shouldSaveEfficiently() {
+        List<PostalCity> list = Arrays.asList(
+            new PostalCity("69000", "LYON"),
+            new PostalCity("42170", "ST JUST ST RAMBERT")
+        );
+        dao.saveAllEfficiently(list);
+
+        assertThat(dao.findByPostalCode("69", 10)).hasSize(1);
+    }
+}

--- a/backend/src/test/java/org/globe42/web/cities/PostalCityControllerMvcTest.java
+++ b/backend/src/test/java/org/globe42/web/cities/PostalCityControllerMvcTest.java
@@ -1,0 +1,64 @@
+package org.globe42.web.cities;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.globe42.dao.PostalCityDao;
+import org.globe42.domain.PostalCity;
+import org.globe42.test.GlobeMvcTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * MVC tests for {@link PostalCityController}
+ * @author JB Nizet
+ */
+@RunWith(SpringRunner.class)
+@GlobeMvcTest(PostalCityController.class)
+public class PostalCityControllerMvcTest {
+
+    @MockBean
+    private PostalCityDao mockPostalCityDao;
+
+    @MockBean
+    private PostalCityUploadParser mockUploadParser;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void shouldSearch() throws Exception {
+        PostalCity postalCity = new PostalCity("42000", "ST ETIENNE");
+        when(mockPostalCityDao.findByCity("ST E", PostalCityController.LIMIT)).thenReturn(
+            Arrays.asList(postalCity)
+        );
+
+        mvc.perform(get("/api/cities").param("query", "ST E"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$[0].code").value("42000"))
+           .andExpect(jsonPath("$[0].city").value("ST ETIENNE"));
+    }
+
+    @Test
+    public void shouldUpload() throws Exception {
+        byte[] body = "fake".getBytes();
+        List<PostalCity> parsedCities = Arrays.asList(new PostalCity("42000", "ST ETIENNE"));
+        when(mockUploadParser.parse(body)).thenReturn(parsedCities);
+
+        mvc.perform(post("/api/cities/uploads").content(body))
+           .andExpect(status().isCreated());
+
+        verify(mockPostalCityDao).saveAllEfficiently(parsedCities);
+    }
+}

--- a/backend/src/test/java/org/globe42/web/cities/PostalCityControllerTest.java
+++ b/backend/src/test/java/org/globe42/web/cities/PostalCityControllerTest.java
@@ -1,0 +1,70 @@
+package org.globe42.web.cities;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.globe42.dao.PostalCityDao;
+import org.globe42.domain.PostalCity;
+import org.globe42.test.BaseTest;
+import org.globe42.web.persons.CityDTO;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+/**
+ * Unit tests for {@link PostalCityController}
+ * @author JB Nizet
+ */
+public class PostalCityControllerTest extends BaseTest {
+    @Mock
+    private PostalCityDao mockPostalCityDao;
+
+    @Mock
+    private PostalCityUploadParser mockUploadParser;
+
+    @InjectMocks
+    private PostalCityController controller;
+
+    @Test
+    public void shouldSearchByPostalCodeWhenQueryIsNumeric() {
+        PostalCity postalCity = new PostalCity("42000", "ST ETIENNE");
+        when(mockPostalCityDao.findByPostalCode("420", PostalCityController.LIMIT)).thenReturn(
+            Arrays.asList(postalCity)
+        );
+
+        List<CityDTO> result = controller.search("420");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCode()).isEqualTo(postalCity.getPostalCode());
+        assertThat(result.get(0).getCity()).isEqualTo(postalCity.getCity());
+    }
+
+    @Test
+    public void shouldSearchByCityWhenQueryIsNotNumeric() {
+        PostalCity postalCity = new PostalCity("42000", "ST ETIENNE");
+        when(mockPostalCityDao.findByCity("ST ET", PostalCityController.LIMIT)).thenReturn(
+            Arrays.asList(postalCity)
+        );
+
+        List<CityDTO> result = controller.search("ST ET");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCode()).isEqualTo(postalCity.getPostalCode());
+        assertThat(result.get(0).getCity()).isEqualTo(postalCity.getCity());
+    }
+
+    @Test
+    public void shouldUpload() {
+        byte[] body = "fake".getBytes();
+        List<PostalCity> parsedCities = Arrays.asList(new PostalCity("42000", "ST ETIENNE"));
+        when(mockUploadParser.parse(body)).thenReturn(parsedCities);
+
+        controller.upload(body);
+
+        verify(mockPostalCityDao).saveAllEfficiently(parsedCities);
+    }
+}

--- a/backend/src/test/java/org/globe42/web/cities/PostalCityUploadParserTest.java
+++ b/backend/src/test/java/org/globe42/web/cities/PostalCityUploadParserTest.java
@@ -1,0 +1,34 @@
+package org.globe42.web.cities;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.globe42.domain.PostalCity;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PostalCityUploadParser}
+ * @author JB Nizet
+ */
+public class PostalCityUploadParserTest {
+    @Test
+    public void shouldParseAndRemoeDuplicates() {
+        //language=TEXT
+        String csv = "Code_commune_INSEE;Nom_commune;Code_postal;Libelle_acheminement;Ligne_5;coordonnees_gps\n" +
+            "10227;MAROLLES SOUS LIGNIERES;10130;No no no;;48.0520003827, 3.93246550297\n" +
+            "10166;LES GRANDES CHAPELLES;10170;LES GRANDES CHAPELLES;;48.4916267047, 3.93350100384\n" +
+            "10232;MERREY SUR ARCE;10110;MERREY SUR ARCE;;48.1160220302, 4.43093259336\n" +
+            "10182;JUVANCOURT;10310;JUVANCOURT;;48.1567685845, 4.79470021531\n" +
+            "10190;LAUBRESSEL;10270;LAUBRESSEL;;48.2596266125, 4.24959642717\n" +
+            "10173;ISLE AUMONT;10800;ISLE AUMONT;;48.2055801821, 4.1125140322\n" +
+            "10196;LIGNIERES;10130;LIGNIERES;;48.0520003827, 3.93246550297\n" +
+            "10197;LIGNIERES;10130;LIGNIERES;OLD NAME;48.0520003827, 3.93246550297";
+
+        List<PostalCity> result = new PostalCityUploadParser().parse(csv.getBytes(StandardCharsets.UTF_8));
+        assertThat(result).hasSize(7);
+        assertThat(result.get(0).getPostalCode()).isEqualTo("10130");
+        assertThat(result.get(0).getCity()).isEqualTo("MAROLLES SOUS LIGNIERES");
+    }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { PersonFamilySituationComponent } from './person-family-situation/person
 import { FamilySituationComponent } from './family-situation/family-situation.component';
 import { DisplayHousingPipe } from './display-housing.pipe';
 import { FamilySituationEditComponent } from './family-situation-edit/family-situation-edit.component';
+import { CitiesUploadComponent } from './cities-upload/cities-upload.component';
 
 @NgModule({
   declarations: [
@@ -88,7 +89,8 @@ import { FamilySituationEditComponent } from './family-situation-edit/family-sit
     PersonFamilySituationComponent,
     FamilySituationComponent,
     DisplayHousingPipe,
-    FamilySituationEditComponent
+    FamilySituationEditComponent,
+    CitiesUploadComponent
   ],
   entryComponents: [
     ConfirmModalContentComponent

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -27,6 +27,7 @@ import { PersonLayoutComponent } from './person-layout/person-layout.component';
 import { PersonIncomesComponent } from './person-incomes/person-incomes.component';
 import { PersonIncomeEditComponent } from './person-income-edit/person-income-edit.component';
 import { PersonFamilySituationComponent } from './person-family-situation/person-family-situation.component';
+import { CitiesUploadComponent } from './cities-upload/cities-upload.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -153,6 +154,10 @@ export const routes: Routes = [
             }
           }
         ]
+      },
+      {
+        path: 'cities',
+        component: CitiesUploadComponent
       }
     ]
   }

--- a/frontend/src/app/cities-upload/cities-upload.component.html
+++ b/frontend/src/app/cities-upload/cities-upload.component.html
@@ -1,0 +1,25 @@
+<h1>Insérer les villes de France</h1>
+
+<ngb-alert type="info" [dismissible]="false" id="info-message">
+  <p>
+    Cet écran permet d'insérer les villes de France dans le système, à partir du fichier CSV téléchargeable
+    <a href="https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/">ici</a>.
+  </p>
+  <p>
+    Cette opération ne doit être faite qu'une fois (à moins que les communes changent à l'avenir).
+  </p>
+</ngb-alert>
+
+<label class="custom-file" *ngIf="status === 'pending'" id="file-input">
+  <input type="file" class="custom-file-input" (change)="upload($event)" accept=".csv">
+  <span class="custom-file-control"></span>
+</label>
+
+<div *ngIf="status !== 'pending'" id="progress">
+  <div class="text-center text-muted">
+    {{ status === 'uploading' ? 'Téléchargement en cours' : (status === 'processing' ? 'Traitement en cours' : (status === 'done' ? 'Terminé' : 'Erreur')) }}
+  </div>
+  <ngb-progressbar [type]="status === 'failed' ? 'danger' : (status === 'done' ? 'success': 'info')" [max]="1" [value]="progress">
+    {{ progress | percent:'1.0-0' }}
+  </ngb-progressbar>
+</div>

--- a/frontend/src/app/cities-upload/cities-upload.component.spec.ts
+++ b/frontend/src/app/cities-upload/cities-upload.component.spec.ts
@@ -1,0 +1,194 @@
+import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
+
+import { CitiesUploadComponent } from './cities-upload.component';
+import { SearchCityService } from '../search-city.service';
+import { Subject } from 'rxjs/Subject';
+import { HttpClientModule, HttpEventType, HttpResponse } from '@angular/common/http';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+describe('CitiesUploadComponent', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NgbModule.forRoot(), HttpClientModule],
+      declarations: [CitiesUploadComponent],
+      providers: [SearchCityService]
+    });
+  }));
+
+  it('should upload', fakeAsync(() => {
+    const cityService = TestBed.get(SearchCityService);
+    const component = new CitiesUploadComponent(cityService);
+
+    expect(component.status).toBe('pending');
+
+    const fileChangeEvent = {
+      target: {
+        files: ['fakeFile']
+      }
+    };
+
+    const fileReader = new FileReader();
+    spyOn(fileReader, 'readAsText');
+
+    spyOn(component, '_createFileReader').and.returnValue(fileReader);
+    let fakeNow = 0;
+    spyOn(component, '_now').and.callFake(() => fakeNow);
+
+    component.upload(fileChangeEvent);
+    expect(fileReader.onload).toBeDefined();
+    expect(fileReader.readAsText).toHaveBeenCalledWith('fakeFile', 'UTF8');
+
+    const fileLoadedEvent: any = {
+      target: {
+        result: 'fakeFileContent'
+      }
+    };
+
+    const fakeEvents = new Subject<any>();
+    spyOn(cityService, 'uploadCities').and.returnValue(fakeEvents);
+
+    fileReader.onload(fileLoadedEvent);
+    expect(component.status).toBe('uploading');
+
+    // emit first progress event after 5 seconds
+    fakeNow += 5000;
+    fakeEvents.next({
+      type: HttpEventType.UploadProgress,
+      loaded: 5,
+      total: 10
+    });
+
+    // upload is halfway and has taken 5 seconds. Estimated processing time is 20 seconds
+    // so total time is 30 seconds and we're thus at 5 / 30
+    expect(component.progress).toBe(5 / 30);
+
+    // emit last progress events
+    fakeNow += 5000;
+    fakeEvents.next({
+      type: HttpEventType.UploadProgress,
+      loaded: 10,
+      total: 10
+    });
+
+    expect(component.progress).toBe(10 / 30);
+    expect(component.status).toBe('processing');
+
+    fakeNow += 10000;
+    tick(10000);
+    expect(component.progress).toBe(20 / 30);
+
+    fakeNow += 5000;
+    tick(5000);
+    expect(component.progress).toBe(25 / 30);
+
+    fakeNow += 6000;
+    tick(6000);
+    expect(component.progress).toBeLessThan(1);
+    expect(component.status).toBe('processing');
+
+    // emit response and complete
+    fakeEvents.next(new HttpResponse());
+    fakeEvents.complete();
+    expect(component.progress).toBe(1);
+    expect(component.status).toBe('done');
+  }));
+
+  it('should finish if response comes back early', fakeAsync(() => {
+    const cityService = TestBed.get(SearchCityService);
+    const component = new CitiesUploadComponent(cityService);
+
+    expect(component.status).toBe('pending');
+
+    const fileChangeEvent = {
+      target: {
+        files: ['fakeFile']
+      }
+    };
+
+    const fileReader = new FileReader();
+    spyOn(fileReader, 'readAsText');
+    spyOn(component, '_createFileReader').and.returnValue(fileReader);
+    let fakeNow = 0;
+    spyOn(component, '_now').and.callFake(() => fakeNow);
+
+    component.upload(fileChangeEvent);
+    expect(fileReader.onload).toBeDefined();
+    expect(fileReader.readAsText).toHaveBeenCalledWith('fakeFile', 'UTF8');
+
+    const fileLoadedEvent: any = {
+      target: {
+        result: 'fakeFileContent'
+      }
+    };
+
+    const fakeEvents = new Subject<any>();
+    spyOn(cityService, 'uploadCities').and.returnValue(fakeEvents);
+
+    fileReader.onload(fileLoadedEvent);
+    expect(component.status).toBe('uploading');
+
+    // emit last progress events
+    fakeNow += 10000;
+    fakeEvents.next({
+      type: HttpEventType.UploadProgress,
+      loaded: 10,
+      total: 10
+    });
+
+    expect(component.progress).toBe(10 / 30);
+    expect(component.status).toBe('processing');
+
+    fakeNow += 15000;
+    tick(15000);
+    expect(component.progress).toBe(25 / 30);
+
+    // emit response and complete
+    fakeEvents.next(new HttpResponse());
+    fakeEvents.complete();
+    expect(component.progress).toBe(1);
+    expect(component.status).toBe('done');
+
+    // let the fake event observable a chance to realize that the processing is done
+    fakeNow += 1000;
+    tick(1000);
+  }));
+
+  it('should display an info message and a file upload control, and no progress', () => {
+    const fixture = TestBed.createComponent(CitiesUploadComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#info-message')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('#file-input')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('#progress')).toBeFalsy();
+  });
+
+  it('should hide the file upload control, and display the progress', () => {
+    const fixture = TestBed.createComponent(CitiesUploadComponent);
+    const component = fixture.componentInstance;
+
+    component.status = 'uploading';
+    component.progress = 0.5;
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#file-input')).toBeFalsy();
+    const progres = fixture.nativeElement.querySelector('#progress');
+    expect(progres.textContent).toContain('Téléchargement en cours');
+    expect(progres.textContent).toContain('50%');
+
+    component.status = 'processing';
+    component.progress = 0.9;
+
+    fixture.detectChanges();
+    expect(progres.textContent).toContain('Traitement en cours');
+    expect(progres.textContent).toContain('90%');
+
+    component.status = 'done';
+    component.progress = 1;
+
+    fixture.detectChanges();
+    expect(progres.textContent).toContain('Terminé');
+    expect(progres.textContent).toContain('100%');
+  });
+});

--- a/frontend/src/app/cities-upload/cities-upload.component.ts
+++ b/frontend/src/app/cities-upload/cities-upload.component.ts
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { SearchCityService } from '../search-city.service';
+import { HttpEventType } from '@angular/common/http';
+import { Observable } from "rxjs/Observable";
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/finally';
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/takeWhile';
+
+const ESTIMATED_PROCESSING_TIME_IN_MILLIS = 20000;
+
+@Component({
+  selector: 'gl-cities-upload',
+  templateUrl: './cities-upload.component.html',
+  styleUrls: ['./cities-upload.component.scss']
+})
+export class CitiesUploadComponent {
+
+  status: 'pending' | 'uploading' | 'processing' | 'done' | 'failed' = 'pending';
+
+  /**
+   * The progress, between 0 and 1
+   */
+  progress: number;
+
+  constructor(private cityService: SearchCityService) { }
+
+  upload(fileChangeEvent) {
+    const file = fileChangeEvent.target.files[0];
+    const reader = this._createFileReader();
+
+    reader.onload = fileLoadedEvent => {
+      this.status = 'uploading';
+      const startTime = this._now();
+
+      this.cityService.uploadCities(fileLoadedEvent.target['result'])
+        .subscribe(progressEvent => {
+          if (progressEvent.type === HttpEventType.UploadProgress) {
+            const elapsedTime = this._now() - startTime;
+            const estimatedUploadTime = (progressEvent.total / progressEvent.loaded) * elapsedTime;
+            const estimatedTotalTime = estimatedUploadTime + ESTIMATED_PROCESSING_TIME_IN_MILLIS;
+
+            this.progress = elapsedTime / estimatedTotalTime;
+
+            if (progressEvent.loaded >= progressEvent.total) {
+              // the upload is done. Now we're processing, and updating the progress each 500 ms.
+              this.status = 'processing';
+
+              // generate fake progress every half-second but
+              // - stop before the end, in case the processing time is longer then estimated
+              // - stop if we received the response, in case the processing time is shorted than estimated
+              Observable.interval(500)
+                .takeWhile(() => (this._now() - startTime) < estimatedTotalTime && this.progress < 1)
+                .subscribe(() => this.progress = (this._now() - startTime) / estimatedTotalTime);
+            }
+          }
+        }, () => {
+          this.progress = 1
+          this.status = 'failed';
+        }, () => {
+          this.progress = 1;
+          this.status = 'done';
+        });
+    };
+
+    reader.readAsText(file, 'UTF8');
+  }
+
+  // to ease testing
+  _createFileReader(): FileReader {
+    return new FileReader();
+  }
+
+  // to ease testing
+  _now() {
+    return new Date().getTime();
+  }
+}

--- a/frontend/src/app/search-city.service.spec.ts
+++ b/frontend/src/app/search-city.service.spec.ts
@@ -23,14 +23,12 @@ describe('SearchCityService', () => {
     service.search('').subscribe(res => expect(res).toEqual([]));
   }));
 
-  it('should request the vicopo API', () => {
+  it('should request the city API', () => {
     const city: CityModel = { city: 'SAINT-ETIENNE', code: 42000 };
-    const body = { cities: [city] };
-
     const expectedResult = [city];
     let actualResult = [];
     service.search('SAINT').subscribe(result => actualResult = result);
-    http.expectOne({ url: 'http://vicopo.selfbuild.fr/cherche/SAINT', method: 'GET' }).flush(body);
+    http.expectOne({ url: '/api/cities?query=SAINT', method: 'GET' }).flush(expectedResult);
 
     expect(actualResult).toEqual(expectedResult);
   });

--- a/frontend/src/app/search-city.service.ts
+++ b/frontend/src/app/search-city.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
@@ -12,20 +12,14 @@ export class SearchCityService {
   constructor(private http: HttpClient) { }
 
   /**
-   * Returns the first 10 cities matching a request
-   * @param term
-   * @returns {any}
+   * Returns the first 20 cities matching a request
    */
   search(term: string): Observable<Array<CityModel>> {
     if (term === '') {
       return Observable.of([]);
     }
 
-    const vicopoUrl = `${window.location.protocol}//vicopo.selfbuild.fr/cherche/${term}`;
-
-    return this.http
-      .get<any>(vicopoUrl)
-      .map(response => response.cities.slice(0, 10) as Array<CityModel>);
+    return this.http.get('/api/cities', { params : new HttpParams().set('query', term)});
   }
 
 }

--- a/frontend/src/app/search-city.service.ts
+++ b/frontend/src/app/search-city.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpParams, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
@@ -12,7 +12,7 @@ export class SearchCityService {
   constructor(private http: HttpClient) { }
 
   /**
-   * Returns the first 20 cities matching a request
+   * Returns the first 10 cities matching a request
    */
   search(term: string): Observable<Array<CityModel>> {
     if (term === '') {
@@ -22,4 +22,11 @@ export class SearchCityService {
     return this.http.get('/api/cities', { params : new HttpParams().set('query', term)});
   }
 
+  uploadCities(data: string): Observable<HttpEvent<any>> {
+    const req = new HttpRequest('POST', '/api/cities/uploads', data, {
+      reportProgress: true,
+    });
+
+    return this.http.request(req);
+  }
 }

--- a/frontend/src/custom-bootstrap.scss
+++ b/frontend/src/custom-bootstrap.scss
@@ -1,6 +1,15 @@
 // make the placeholders lighter
 $input-color-placeholder:        #dcdedf !default;
 
+$custom-file-text: (
+  placeholder: (
+    fr: "Choisir un fichier..."
+  ),
+  button-label: (
+    fr: "Parcourir"
+  )
+);
+
 // Core variables and mixins
 @import "../node_modules/bootstrap/scss/variables";
 
@@ -26,7 +35,7 @@ $input-color-placeholder:        #dcdedf !default;
 @import "../node_modules/bootstrap/scss/dropdown";
 @import "../node_modules/bootstrap/scss/button-group";
 @import "../node_modules/bootstrap/scss/input-group";
-// @import "../node_modules/bootstrap/scss/custom-forms";
+@import "../node_modules/bootstrap/scss/custom-forms";
 @import "../node_modules/bootstrap/scss/nav";
 @import "../node_modules/bootstrap/scss/navbar";
 @import "../node_modules/bootstrap/scss/card";

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="favicon.png">
 </head>
-<body>
-  <gl-root>Loading...</gl-root>
+<body lang="fr">
+  <gl-root>Chargement...</gl-root>
 </body>
 </html>


### PR DESCRIPTION
fix for #66: introduce our own API to search cities.

This needs to load the database with the postal codes and cities. I initially started with just a REST API, and used curl to load the data, but then I thought playing with file uploads in Bootstrap + Angular + the FileReader API, and display a progress bar for the upload and the processing could be fun, and a good learning experience.

It was actually quite simple to achieve, and I like the result.

I didn't add any link to this upload page, since it should normally be used just once, but you can test it at the URL /cities. It displays instructions on where to find the file to upload. For a real experience, before uploading, open your chrome dev tools, go to the network tab, and choose to throttle using DSL.

The upload starts by removing all the cities, so you can try it as many times you want to.