### PR TITLE
feat(tasks): add spent times on tasks

### DIFF
--- a/backend/src/main/java/org/globe42/dao/SpentTimeDao.java
+++ b/backend/src/main/java/org/globe42/dao/SpentTimeDao.java
@@ -1,0 +1,19 @@
+package org.globe42.dao;
+
+import org.globe42.domain.SpentTime;
+import org.globe42.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * DAO for {@link SpentTime}
+ * @author JB Nizet
+ */
+public interface SpentTimeDao extends JpaRepository<SpentTime, Long> {
+
+    @Query("update SpentTime spentTime set spentTime.creator = null where spentTime.creator = :user")
+    @Modifying
+    void resetCreatorOnSpentTimesCreatedBy(@Param("user") User user);
+}

--- a/backend/src/main/java/org/globe42/domain/SpentTime.java
+++ b/backend/src/main/java/org/globe42/domain/SpentTime.java
@@ -1,0 +1,101 @@
+package org.globe42.domain;
+
+import java.time.Instant;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * A piece of time spent on a given task
+ * @author JB Nizet
+ */
+@Entity
+public class SpentTime {
+    private static final String SPENT_TIME_GENERATOR = "SpentTimeGenerator";
+
+    @Id
+    @SequenceGenerator(name = SPENT_TIME_GENERATOR, sequenceName = "SPENT_TIME_SEQ", initialValue = 1000, allocationSize = 1)
+    @GeneratedValue(generator = SPENT_TIME_GENERATOR)
+    private Long id;
+
+    /**
+     * The number of minutes (always positive) spent on the task. The total time spent on the task is the sum of the
+     * minutes of all the instances linked to a task. To speed things up however, this total is also recomputed
+     * every time a spent time is added or deleted and stored directly in the task
+     */
+    @Min(1)
+    private int minutes;
+
+    /**
+     * The task on which those minutes have been spent
+     */
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Task task;
+
+    /**
+     * The user which recorded this time spent on the task (another person might have spent the actual time).
+     * If the user is deleted, the creator will be set to null, to avoid losing spent times.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User creator;
+
+    /**
+     * The time when this spent time was created (might be later than the actual instant when the time was actually
+     * spent)
+     */
+    @NotNull
+    private Instant creationInstant = Instant.now();
+
+    public SpentTime() {
+    }
+
+    public SpentTime(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getMinutes() {
+        return minutes;
+    }
+
+    public void setMinutes(int minutes) {
+        this.minutes = minutes;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public User getCreator() {
+        return creator;
+    }
+
+    public void setCreator(User creator) {
+        this.creator = creator;
+    }
+
+    public Instant getCreationInstant() {
+        return creationInstant;
+    }
+
+    public void setCreationInstant(Instant creationTime) {
+        this.creationInstant = creationTime;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/tasks/SpentTimeCommandDTO.java
+++ b/backend/src/main/java/org/globe42/web/tasks/SpentTimeCommandDTO.java
@@ -1,0 +1,21 @@
+package org.globe42.web.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Command used to add a spent time on a task
+ * @author JB Nizet
+ */
+public final class SpentTimeCommandDTO {
+    private final int minutes;
+
+    @JsonCreator
+    public SpentTimeCommandDTO(@JsonProperty("minutes") int minutes) {
+        this.minutes = minutes;
+    }
+
+    public int getMinutes() {
+        return minutes;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/tasks/SpentTimeDTO.java
+++ b/backend/src/main/java/org/globe42/web/tasks/SpentTimeDTO.java
@@ -1,0 +1,40 @@
+package org.globe42.web.tasks;
+
+import java.time.Instant;
+
+import org.globe42.domain.SpentTime;
+import org.globe42.web.users.UserDTO;
+
+/**
+ * DTO for a {@link SpentTime}
+ * @author JB Nizet
+ */
+public final class SpentTimeDTO {
+    private final Long id;
+    private final int minutes;
+    private final UserDTO creator;
+    private final Instant creationInstant;
+
+    public SpentTimeDTO(SpentTime spentTime) {
+        this.id = spentTime.getId();
+        this.minutes = spentTime.getMinutes();
+        this.creator = spentTime.getCreator() == null ? null : new UserDTO(spentTime.getCreator());
+        this.creationInstant = spentTime.getCreationInstant();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getMinutes() {
+        return minutes;
+    }
+
+    public UserDTO getCreator() {
+        return creator;
+    }
+
+    public Instant getCreationInstant() {
+        return creationInstant;
+    }
+}

--- a/backend/src/main/java/org/globe42/web/tasks/TaskDTO.java
+++ b/backend/src/main/java/org/globe42/web/tasks/TaskDTO.java
@@ -20,6 +20,7 @@ public final class TaskDTO {
     private final UserDTO creator;
     private final UserDTO assignee;
     private final PersonIdentityDTO concernedPerson;
+    private final int totalSpentTimeInMinutes;
 
     public TaskDTO(Task task) {
         this.id = task.getId();
@@ -30,6 +31,7 @@ public final class TaskDTO {
         this.creator = task.getCreator() == null ? null : new UserDTO(task.getCreator());
         this.assignee = task.getAssignee() == null ? null : new UserDTO(task.getAssignee());
         this.concernedPerson = task.getConcernedPerson() == null ? null : new PersonIdentityDTO(task.getConcernedPerson());
+        this.totalSpentTimeInMinutes = task.getTotalSpentTimeInMinutes();
     }
 
     public Long getId() {
@@ -62,5 +64,9 @@ public final class TaskDTO {
 
     public PersonIdentityDTO getConcernedPerson() {
         return concernedPerson;
+    }
+
+    public int getTotalSpentTimeInMinutes() {
+        return totalSpentTimeInMinutes;
     }
 }

--- a/backend/src/main/java/org/globe42/web/users/UserController.java
+++ b/backend/src/main/java/org/globe42/web/users/UserController.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 
 import org.globe42.dao.NoteDao;
+import org.globe42.dao.SpentTimeDao;
 import org.globe42.dao.TaskDao;
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
@@ -39,6 +40,7 @@ public class UserController {
     private final UserDao userDao;
     private final TaskDao taskDao;
     private final NoteDao noteDao;
+    private final SpentTimeDao spentTimeDao;
     private final PasswordGenerator passwordGenerator;
     private final PasswordDigester passwordDigester;
 
@@ -46,12 +48,14 @@ public class UserController {
                           UserDao userDao,
                           TaskDao taskDao,
                           NoteDao noteDao,
+                          SpentTimeDao spentTimeDao,
                           PasswordGenerator passwordGenerator,
                           PasswordDigester passwordDigester) {
         this.currentUser = currentUser;
         this.userDao = userDao;
         this.taskDao = taskDao;
         this.noteDao = noteDao;
+        this.spentTimeDao = spentTimeDao;
         this.passwordGenerator = passwordGenerator;
         this.passwordDigester = passwordDigester;
     }
@@ -121,6 +125,7 @@ public class UserController {
             taskDao.resetAssigneeOnTasksAssignedTo(user);
             taskDao.resetCreatorOnTasksCreatedBy(user);
             noteDao.resetCreatorOnNotesCreatedBy(user);
+            spentTimeDao.resetCreatorOnSpentTimesCreatedBy(user);
             userDao.delete(user);
         });
     }

--- a/backend/src/main/resources/db/migration/V0016__spent_time.sql
+++ b/backend/src/main/resources/db/migration/V0016__spent_time.sql
@@ -1,0 +1,23 @@
+CREATE TABLE spent_time (
+  id               BIGINT PRIMARY KEY,
+  minutes          INT NULL,
+  task_id          BIGINT,
+  creator_id       BIGINT,
+  creation_instant TIMESTAMPTZ
+);
+
+ALTER TABLE spent_time
+  ADD CONSTRAINT task_fk1 FOREIGN KEY (task_id) REFERENCES task (id);
+ALTER TABLE spent_time
+  ADD CONSTRAINT task_fk2 FOREIGN KEY (creator_id) REFERENCES guser (id);
+
+CREATE SEQUENCE spent_time_seq START WITH 1000;
+
+ALTER TABLE task
+  ADD COLUMN total_spent_time_in_minutes INT;
+
+UPDATE task
+SET total_spent_time_in_minutes = 0;
+
+ALTER TABLE task
+  ALTER total_spent_time_in_minutes SET NOT NULL;

--- a/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/BaseDaoTest.java
@@ -32,6 +32,7 @@ public abstract class BaseDaoTest {
 
     private static final Operation DELETE_ALL = DeleteAll.from("person_note",
                                                                "note",
+                                                               "spent_time",
                                                                "task",
                                                                "guser",
                                                                "income",

--- a/backend/src/test/java/org/globe42/dao/SpentTimeDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/SpentTimeDaoTest.java
@@ -1,0 +1,64 @@
+package org.globe42.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ninja_squad.dbsetup.Operations;
+import com.ninja_squad.dbsetup.operation.Insert;
+import com.ninja_squad.dbsetup.operation.Operation;
+import org.globe42.domain.FiscalStatus;
+import org.globe42.domain.Gender;
+import org.globe42.domain.HealthCareCoverage;
+import org.globe42.domain.Housing;
+import org.globe42.domain.MaritalStatus;
+import org.globe42.domain.TaskStatus;
+import org.globe42.domain.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for {@link SpentTimeDao}
+ * @author JB Nizet
+ */
+public class SpentTimeDaoTest extends BaseDaoTest {
+
+    @Autowired
+    private SpentTimeDao dao;
+
+    @Before
+    public void prepare() {
+        Operation persons =
+            Insert.into("person")
+                  .withDefaultValue("fiscal_status_up_to_date", false)
+                  .withDefaultValue("fiscal_status", FiscalStatus.UNKNOWN)
+                  .withDefaultValue("marital_status", MaritalStatus.UNKNOWN)
+                  .withDefaultValue("housing", Housing.UNKNOWN)
+                  .withDefaultValue("health_care_coverage", HealthCareCoverage.UNKNOWN)
+                  .columns("id", "first_name", "last_name", "gender", "adherent", "mediation_enabled")
+                  .values(1L, "Cedric", "Exbrayat", Gender.MALE, true, false)
+                  .build();
+
+        Operation users = Insert.into("guser")
+                                .columns("id", "login", "password", "admin")
+                                .values(1L, "jb", "hashedPassword", true)
+                                .build();
+        Operation tasks = Insert.into("task")
+                                .columns("id", "status", "title", "description")
+                                .withDefaultValue("total_spent_time_in_minutes", 0)
+                                .values(1L, TaskStatus.DONE, "task 1", "task desc 1")
+                                .build();
+
+        Operation spentTimes = Insert.into("spent_time")
+                                     .columns("id", "minutes", "task_id", "creation_instant", "creator_id")
+                                     .values(1L, 10, 1L, "2017-11-01", 1L)
+                                     .build();
+
+        dbSetup(Operations.sequenceOf(users, persons, tasks, spentTimes));
+    }
+
+    @Test
+    public void shouldResetCreator() {
+        dao.resetCreatorOnSpentTimesCreatedBy(new User(1L));
+        assertThat(dao.findById(1L).get().getCreator()).isNull();
+    }
+}

--- a/backend/src/test/java/org/globe42/dao/TaskDaoTest.java
+++ b/backend/src/test/java/org/globe42/dao/TaskDaoTest.java
@@ -55,6 +55,7 @@ public class TaskDaoTest extends BaseDaoTest {
         Operation tasks = Insert.into("task")
                                 .withGeneratedValue("description", ValueGenerators.stringSequence("desc_"))
                                 .withGeneratedValue("title", ValueGenerators.stringSequence("title_"))
+                                .withDefaultValue("total_spent_time_in_minutes", 0)
                                 .columns("id", "status", "due_date", "creator_id", "assignee_id", "concerned_person_id", "archival_instant")
                                 .values(1L, TaskStatus.DONE, null, 1L, 1L, null, Instant.parse("2017-08-04T00:00:00Z"))
                                 .values(2L, TaskStatus.TODO, null, 1L, 2L, null, null)

--- a/backend/src/test/java/org/globe42/web/users/UserControllerMvcTest.java
+++ b/backend/src/test/java/org/globe42/web/users/UserControllerMvcTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.globe42.dao.NoteDao;
+import org.globe42.dao.SpentTimeDao;
 import org.globe42.dao.TaskDao;
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
@@ -42,6 +43,9 @@ public class UserControllerMvcTest {
 
     @MockBean
     private NoteDao mockNoteDao;
+
+    @MockBean
+    private SpentTimeDao mockSpentTimeDao;
 
     @MockBean
     private PasswordGenerator mockPasswordGenerator;

--- a/backend/src/test/java/org/globe42/web/users/UserControllerTest.java
+++ b/backend/src/test/java/org/globe42/web/users/UserControllerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.globe42.dao.NoteDao;
+import org.globe42.dao.SpentTimeDao;
 import org.globe42.dao.TaskDao;
 import org.globe42.dao.UserDao;
 import org.globe42.domain.User;
@@ -40,6 +41,9 @@ public class UserControllerTest extends BaseTest{
 
     @Mock
     private NoteDao mockNoteDao;
+
+    @Mock
+    private SpentTimeDao mockSpentTimeDao;
 
     @Mock
     private PasswordGenerator mockPasswordGenerator;
@@ -184,6 +188,7 @@ public class UserControllerTest extends BaseTest{
         verify(mockTaskDao).resetAssigneeOnTasksAssignedTo(user);
         verify(mockTaskDao).resetCreatorOnTasksCreatedBy(user);
         verify(mockNoteDao).resetCreatorOnNotesCreatedBy(user);
+        verify(mockSpentTimeDao).resetCreatorOnSpentTimesCreatedBy(user);
         verify(mockUserDao).delete(user);
     }
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -101,6 +101,9 @@ import { MinValidatorDirective } from './min-validator.directive';
 import { MaxValidatorDirective } from './max-validator.directive';
 
 registerLocaleData(localeFr);
+import { DurationPipe } from './duration.pipe';
+import { SpentTimesComponent } from './spent-times/spent-times.component';
+import { SpentTimeAddComponent } from './spent-time-add/spent-time-add.component';
 
 @NgModule({
   declarations: [
@@ -155,7 +158,10 @@ registerLocaleData(localeFr);
     ActivityTypesComponent,
     ParticipantsComponent,
     MinValidatorDirective,
-    MaxValidatorDirective
+    MaxValidatorDirective,
+    DurationPipe,
+    SpentTimesComponent,
+    SpentTimeAddComponent
   ],
   entryComponents: [
     ConfirmModalContentComponent

--- a/frontend/src/app/duration.pipe.spec.ts
+++ b/frontend/src/app/duration.pipe.spec.ts
@@ -1,0 +1,12 @@
+import { DurationPipe } from './duration.pipe';
+
+describe('DurationPipe', () => {
+  it('should format a duration in minutes', () => {
+    const pipe = new DurationPipe();
+    expect(pipe.transform(0)).toBe('0h00m');
+    expect(pipe.transform(5)).toBe('0h05m');
+    expect(pipe.transform(15)).toBe('0h15m');
+    expect(pipe.transform(65)).toBe('1h05m');
+    expect(pipe.transform(119)).toBe('1h59m');
+  });
+});

--- a/frontend/src/app/duration.pipe.ts
+++ b/frontend/src/app/duration.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'duration'
+})
+export class DurationPipe implements PipeTransform {
+
+  transform(minutes: number): string {
+    return `${Math.trunc(minutes / 60)}h${this.leftPadZero(minutes % 60)}m`;
+  }
+
+  private leftPadZero(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+  }
+}

--- a/frontend/src/app/models/spent-time.model.ts
+++ b/frontend/src/app/models/spent-time.model.ts
@@ -1,0 +1,8 @@
+import { UserModel } from './user.model';
+
+export interface SpentTimeModel {
+  id: number;
+  minutes: number;
+  creator: UserModel;
+  creationInstant: string;
+}

--- a/frontend/src/app/models/task.model.ts
+++ b/frontend/src/app/models/task.model.ts
@@ -10,4 +10,5 @@ export interface TaskModel {
   assignee: UserModel;
   creator: UserModel;
   concernedPerson: PersonIdentityModel;
+  totalSpentTimeInMinutes: number;
 }

--- a/frontend/src/app/spent-time-add/spent-time-add.component.html
+++ b/frontend/src/app/spent-time-add/spent-time-add.component.html
@@ -1,0 +1,13 @@
+<form class="form-inline" (ngSubmit)="add()" #addForm="ngForm">
+  <div class="form-group">
+    <input type="number" class="form-control form-control-sm" style="width: 4rem;" name="hours" [(ngModel)]="model.hours" required min="0"/>
+    &nbsp;h
+  </div>
+  <div class="form-group">
+    <input type="number" class="form-control form-control-sm ml-sm-2" style="width: 4rem;" name="minutes" [(ngModel)]="model.minutes" required min="0"/>
+    &nbsp;m.
+  </div>
+
+  <button type="submit" class="btn btn-primary btn-sm ml-sm-2" [disabled]="addForm.invalid || !isAddable()">Ajouter</button>
+  <button type="button" class="btn btn-danger btn-sm ml-sm-2" (click)="cancel()">Annuler</button>
+</form>

--- a/frontend/src/app/spent-time-add/spent-time-add.component.spec.ts
+++ b/frontend/src/app/spent-time-add/spent-time-add.component.spec.ts
@@ -1,0 +1,94 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpentTimeAddComponent } from './spent-time-add.component';
+import { Component } from '@angular/core';
+import { TaskModel } from '../models/task.model';
+import { SpentTimeEvent } from '../tasks/tasks.component';
+import { TaskService } from '../task.service';
+import { NowService } from '../now.service';
+import { UserService } from '../user.service';
+import { JwtInterceptorService } from '../jwt-interceptor.service';
+import { HttpClientModule } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { SpentTimeModel } from '../models/spent-time.model';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+@Component({
+  template: `<gl-spent-time-add [taskModel]="task"
+                                (cancelled)="onCancelled($event)"
+                                (spentTimeAdded)="onSpentTimeAdded($event)"></gl-spent-time-add>`
+})
+class TestComponent {
+  task = {
+    id: 42
+  } as TaskModel;
+
+  cancelled = false;
+  spentTimeAddedEvent: SpentTimeEvent;
+
+  onCancelled(event: SpentTimeEvent) {
+    this.cancelled = true;
+  }
+
+  onSpentTimeAdded(event: SpentTimeEvent) {
+    this.spentTimeAddedEvent = event;
+  }
+}
+
+describe('SpentTimeAddComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SpentTimeAddComponent, TestComponent],
+      providers: [
+        TaskService,
+        NowService,
+        UserService,
+        JwtInterceptorService
+      ],
+      imports: [HttpClientModule, FormsModule]
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+  }));
+
+  it('should have 0h0m as default inputs, and not allow to subit', () => {
+    const inputs: Array<HTMLInputElement> = fixture.nativeElement.querySelectorAll('input');
+    expect(inputs[0].value).toBe('0');
+    expect(inputs[1].value).toBe('0');
+    expect(fixture.nativeElement.querySelector('button').disabled).toBe(true);
+  });
+
+  it('should cancel', () => {
+    fixture.nativeElement.querySelectorAll('button')[1].click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.cancelled).toBe(true);
+  });
+
+  it('should add', () => {
+    const inputs: Array<HTMLInputElement> = fixture.nativeElement.querySelectorAll('input');
+    inputs[0].value = '1';
+    inputs[0].dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    const addButton: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(addButton.disabled).toBe(false);
+
+    inputs[1].value = '10';
+    inputs[1].dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const taskService = TestBed.get(TaskService);
+    const spentTime = { id: 1 } as SpentTimeModel;
+    spyOn(taskService, 'addSpentTime').and.returnValue(Observable.of(spentTime));
+
+    addButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.spentTimeAddedEvent.task.id).toBe(42);
+    expect(fixture.componentInstance.spentTimeAddedEvent.spentTime.id).toBe(1);
+    expect(taskService.addSpentTime).toHaveBeenCalledWith(42, 70);
+  });
+});

--- a/frontend/src/app/spent-time-add/spent-time-add.component.ts
+++ b/frontend/src/app/spent-time-add/spent-time-add.component.ts
@@ -1,0 +1,40 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { TaskModel } from '../models/task.model';
+import { TaskService } from '../task.service';
+import { SpentTimeModel } from '../models/spent-time.model';
+import { SpentTimeEvent } from '../tasks/tasks.component';
+
+@Component({
+  selector: 'gl-spent-time-add',
+  templateUrl: './spent-time-add.component.html',
+  styleUrls: ['./spent-time-add.component.scss']
+})
+export class SpentTimeAddComponent {
+
+  @Input() taskModel: TaskModel;
+
+  @Output() spentTimeAdded = new EventEmitter<SpentTimeEvent>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  model = {
+    hours: 0,
+    minutes: 0
+  };
+
+  constructor(private taskService: TaskService) { }
+
+  isAddable() {
+    return this.model.hours > 0 || this.model.minutes > 0;
+  }
+
+  add() {
+    const minutes = this.model.minutes + this.model.hours * 60;
+    this.taskService.addSpentTime(this.taskModel.id, minutes).subscribe(spentTime => {
+      this.spentTimeAdded.emit({ task: this.taskModel, spentTime });
+    });
+  }
+
+  cancel() {
+    this.cancelled.emit();
+  }
+}

--- a/frontend/src/app/spent-times/spent-times.component.html
+++ b/frontend/src/app/spent-times/spent-times.component.html
@@ -1,0 +1,7 @@
+<ul>
+  <li *ngFor="let spentTime of spentTimes">
+    {{ spentTime.creationInstant | date:'medium' }}: {{ spentTime.minutes | duration }}
+    <ng-container *ngIf="spentTime.creator">par {{ spentTime.creator.login }}</ng-container>
+    <a href="#" (click)="delete(spentTime, $event)"><span class="fa fa-trash"></span> Supprimer</a>
+  </li>
+</ul>

--- a/frontend/src/app/spent-times/spent-times.component.spec.ts
+++ b/frontend/src/app/spent-times/spent-times.component.spec.ts
@@ -1,0 +1,151 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpentTimesComponent } from './spent-times.component';
+import { Component, LOCALE_ID } from '@angular/core';
+import { TaskModel } from '../models/task.model';
+import { SpentTimeEvent } from '../tasks/tasks.component';
+import { TaskService } from '../task.service';
+import Spy = jasmine.Spy;
+import { Observable } from 'rxjs/Observable';
+import { SpentTimeModel } from '../models/spent-time.model';
+import { Subject } from 'rxjs/Subject';
+import { HttpClientModule } from '@angular/common/http';
+import 'rxjs/add/observable/of';
+import { DurationPipe } from '../duration.pipe';
+import { NowService } from '../now.service';
+import { UserService } from '../user.service';
+import { JwtInterceptorService } from '../jwt-interceptor.service';
+
+@Component({
+  template: `<gl-spent-times [taskModel]="taskModel" (spentTimeDeleted)="storeDeletedSpentTime($event)"></gl-spent-times>`
+})
+class TestComponent {
+  taskModel = {
+    id: 42
+  } as TaskModel;
+
+  deletedSpentTimeEvent: SpentTimeEvent;
+
+  storeDeletedSpentTime(event: SpentTimeEvent) {
+    this.deletedSpentTimeEvent = event;
+  }
+}
+
+describe('SpentTimesComponent', () => {
+  describe('logic', () => {
+    it('should list spent times', () => {
+      const taskService: TaskService = jasmine.createSpyObj(['listSpentTimes']);
+      const task = {
+        id: 42
+      } as TaskModel;
+
+      const spentTimes = [
+        {
+          id: 1
+        }
+      ] as Array<SpentTimeModel>;
+      (taskService.listSpentTimes as Spy).and.returnValue(Observable.of(spentTimes));
+
+      const component = new SpentTimesComponent(taskService);
+      component.taskModel = task;
+      component.ngOnInit();
+
+      expect(component.spentTimes).toEqual(spentTimes);
+      expect(taskService.listSpentTimes).toHaveBeenCalledWith(task.id);
+    });
+
+    it('should delete spent time', () => {
+      const taskService: TaskService = jasmine.createSpyObj(['deleteSpentTime']);
+      const task = {
+        id: 42
+      } as TaskModel;
+
+      const component = new SpentTimesComponent(taskService);
+      component.spentTimes = [
+        {
+          id: 1,
+        },
+        {
+          id: 2,
+        }
+      ] as Array<SpentTimeModel>;
+
+      component.taskModel = task;
+
+      const deletionResult = new Subject<void>();
+      (taskService.deleteSpentTime as Spy).and.returnValue(deletionResult);
+
+      spyOn(component.spentTimeDeleted, 'emit');
+      const event = new Event('click');
+      component.delete(component.spentTimes[0], event);
+
+      deletionResult.next(null);
+
+      expect(component.spentTimes).toEqual([{ id: 2 }] as Array<SpentTimeModel>);
+      expect(component.spentTimeDeleted.emit).toHaveBeenCalledWith({
+        task,
+        spentTime: { id: 1 }
+      });
+    });
+  });
+
+  describe('UI', () => {
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        declarations: [SpentTimesComponent, TestComponent, DurationPipe],
+        providers: [
+          TaskService,
+          NowService,
+          UserService,
+          JwtInterceptorService,
+          { provide: LOCALE_ID, useValue: 'fr-FR' }
+        ],
+        imports: [HttpClientModule]
+      });
+
+      const taskService = TestBed.get(TaskService);
+      spyOn(taskService, 'listSpentTimes').and.returnValue(Observable.of([
+        {
+          id: 2,
+          minutes: 12,
+          creator: null,
+          creationInstant: '2018-11-03T14:13:00.000Z'
+        },
+        {
+          id: 1,
+          minutes: 100,
+          creator: { login: 'JB' },
+          creationInstant: '2018-11-03T12:13:00.000Z'
+        }
+      ]));
+
+      spyOn(taskService, 'deleteSpentTime').and.returnValue(Observable.of(null));
+
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+    }));
+
+    it('should list spent times', () => {
+      const itemElements = fixture.nativeElement.querySelectorAll('li');
+      expect(itemElements.length).toBe(2);
+
+      // avoid using contains because the exact value depends on the browser timezone
+      expect(itemElements[0].textContent).toMatch(/\d nov. 2018 à \d\d:13:00: 0h12m/);
+      expect(itemElements[0].textContent).not.toContain('par');
+      expect(itemElements[1].textContent).toMatch(/\d nov. 2018 à \d\d:13:00: 1h40m/);
+      expect(itemElements[1].textContent).toContain('par JB');
+    });
+
+    it('should delete', () => {
+      const deleteLink: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+      deleteLink.click();
+      fixture.detectChanges();
+
+      const itemElements = fixture.nativeElement.querySelectorAll('li');
+      expect(itemElements.length).toBe(1);
+      expect(fixture.componentInstance.deletedSpentTimeEvent.spentTime.id).toBe(2);
+    });
+  });
+});

--- a/frontend/src/app/spent-times/spent-times.component.ts
+++ b/frontend/src/app/spent-times/spent-times.component.ts
@@ -1,0 +1,36 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { TaskModel } from '../models/task.model';
+import { TaskService } from '../task.service';
+import { SpentTimeModel } from '../models/spent-time.model';
+import { SpentTimeEvent } from '../tasks/tasks.component';
+
+@Component({
+  selector: 'gl-spent-times',
+  templateUrl: './spent-times.component.html',
+  styleUrls: ['./spent-times.component.scss']
+})
+export class SpentTimesComponent implements OnInit {
+
+  @Input()
+  taskModel: TaskModel;
+
+  @Output()
+  spentTimeDeleted = new EventEmitter<SpentTimeEvent>();
+
+  spentTimes: Array<SpentTimeModel>;
+
+  constructor(private taskService: TaskService) { }
+
+  ngOnInit() {
+    this.taskService.listSpentTimes(this.taskModel.id).subscribe(list => this.spentTimes = list);
+  }
+
+  delete(spentTime: SpentTimeModel, event: Event) {
+    this.taskService.deleteSpentTime(this.taskModel.id, spentTime.id).subscribe(() => {
+      this.spentTimes.splice(this.spentTimes.indexOf(spentTime), 1);
+      this.spentTimeDeleted.emit({ task: this.taskModel, spentTime });
+    });
+    event.stopPropagation();
+    event.preventDefault();
+  }
+}

--- a/frontend/src/app/task.service.spec.ts
+++ b/frontend/src/app/task.service.spec.ts
@@ -9,6 +9,7 @@ import { NowService } from './now.service';
 import { Page } from './models/page';
 import { UserService } from './user.service';
 import { JwtInterceptorService } from './jwt-interceptor.service';
+import { SpentTimeModel } from './models/spent-time.model';
 import { HttpTester } from './http-tester.spec';
 import { UserModel } from './models/user.model';
 
@@ -80,5 +81,23 @@ describe('TaskService', () => {
 
   it('should resurrect a task', () => {
     httpTester.testPost('/api/tasks/1/status-changes', { newStatus: 'TODO' }, null, service.resurrect(1));
+  });
+
+  it('should list spent times', () => {
+    const expectedSpentTimes = [{ id: 1 }] as Array<SpentTimeModel>;
+    httpTester.testGet('/api/tasks/42/spent-times', expectedSpentTimes, service.listSpentTimes(42));
+  });
+
+  it('should create a spent time', () => {
+    const expectedSpentTime = { id: 1 } as SpentTimeModel;
+    httpTester.testPost(
+      '/api/tasks/42/spent-times',
+      { minutes: 10 },
+      expectedSpentTime,
+      service.addSpentTime(42, 10));
+  });
+
+  it('should delete a spent time', () => {
+    httpTester.testDelete('/api/tasks/42/spent-times/1', service.deleteSpentTime(42, 1));
   });
 });

--- a/frontend/src/app/task.service.ts
+++ b/frontend/src/app/task.service.ts
@@ -6,6 +6,8 @@ import { NowService } from './now.service';
 import { Page } from './models/page';
 import { UserService } from './user.service';
 import { TaskCommand } from './models/task.command';
+import { SpentTimeModel } from './models/spent-time.model';
+import { sortBy } from './utils';
 
 function pageParams(pageNumber: number): HttpParams {
   return new HttpParams().set('page', pageNumber.toString());
@@ -75,5 +77,18 @@ export class TaskService {
 
   get(id: number): Observable<TaskModel> {
     return this.http.get<TaskModel>(`/api/tasks/${id}`);
+  }
+
+  listSpentTimes(taskId: number): Observable<Array<SpentTimeModel>> {
+    return this.http.get<Array<SpentTimeModel>>(`/api/tasks/${taskId}/spent-times`)
+      .map(list => sortBy(list, spentTime => spentTime.creationInstant, true));
+  }
+
+  deleteSpentTime(taskId: number, spentTimeId: number): Observable<void> {
+    return this.http.delete<void>(`/api/tasks/${taskId}/spent-times/${spentTimeId}`);
+  }
+
+  addSpentTime(taskId: number, minutes: number): Observable<SpentTimeModel> {
+    return this.http.post<SpentTimeModel>(`/api/tasks/${taskId}/spent-times`, { minutes });
   }
 }

--- a/frontend/src/app/tasks-page/tasks-page.component.spec.ts
+++ b/frontend/src/app/tasks-page/tasks-page.component.spec.ts
@@ -18,6 +18,9 @@ import { TasksResolverService } from '../tasks-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
 import { UserService } from '../user.service';
 import { JwtInterceptorService } from '../jwt-interceptor.service';
+import { SpentTimesComponent } from '../spent-times/spent-times.component';
+import { SpentTimeAddComponent } from '../spent-time-add/spent-time-add.component';
+import { DurationPipe } from '../duration.pipe';
 
 describe('TasksPageComponent', () => {
   let page: Page<TaskModel>;
@@ -37,6 +40,7 @@ describe('TasksPageComponent', () => {
           title: 'Some title',
           dueDate: '2017-08-01',
           status: 'DONE',
+          totalSpentTimeInMinutes: 0,
           assignee: null,
           creator: null,
           concernedPerson: null
@@ -66,9 +70,19 @@ describe('TasksPageComponent', () => {
       }
     } as any;
 
+    TestBed.overrideTemplate(SpentTimeAddComponent, '');
+    TestBed.overrideTemplate(SpentTimesComponent, '');
+
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, NgbModule.forRoot(), HttpClientModule],
-      declarations: [TasksPageComponent, TasksComponent, FullnamePipe],
+      declarations: [
+        TasksPageComponent,
+        TasksComponent,
+        FullnamePipe,
+        SpentTimesComponent,
+        SpentTimeAddComponent,
+        DurationPipe
+      ],
       providers: [
         NowService,
         TaskService,

--- a/frontend/src/app/tasks/tasks.component.html
+++ b/frontend/src/app/tasks/tasks.component.html
@@ -1,17 +1,30 @@
 <div class="list-group task-item" *ngIf="tasks.length > 0">
-  <a href (click)="toggle(task, $event)" *ngFor="let task of tasks" class="list-group-item list-group-item-action flex-column align-items-start">
-    <div class="d-flex w-100 justify-content-between task-title">
-      <h2>{{ task.model.title }}</h2>
-      <small *ngIf="task.model.status === 'TODO' && task.model.dueDate" [class]="task.dueDateClass()">{{ task.relativeDueDate() }}</small>
-      <small *ngIf="task.model.status === 'DONE'" class="text-success"><span class="fa fa-check"></span> Faite</small>
-      <small *ngIf="task.model.status === 'CANCELLED'" class="text-danger"><span class="fa fa-times"></span> Annulée</small>
-    </div>
-    <div *ngIf="task.opened" class="task-description">{{ task.model.description }}</div>
+  <div *ngFor="let task of tasks" class="list-group-item flex-column align-items-start">
+    <a href (click)="toggle(task, $event)" class="list-group-item-action">
+      <div class="d-flex w-100 justify-content-between task-title">
+        <h2>{{ task.model.title }}</h2>
+        <small *ngIf="task.model.status === 'TODO' && task.model.dueDate" [class]="task.dueDateClass()">{{ task.relativeDueDate() }}</small>
+        <small *ngIf="task.model.status === 'DONE'" class="text-success"><span class="fa fa-check"></span> Faite</small>
+        <small *ngIf="task.model.status === 'CANCELLED'" class="text-danger"><span class="fa fa-times"></span> Annulée</small>
+      </div>
+      <div *ngIf="task.opened" class="task-description">{{ task.model.description }}</div>
+    </a>
     <div class="d-flex w-100 justify-content-between align-items-start">
-      <div>
-        <small class="text-muted" *ngIf="task.model.creator">Créée par {{ task.model.creator.login }}.</small>
-        <small class="text-muted" *ngIf="task.model.assignee">Assignée à {{ task.model.assignee.login }}.</small>
-        <small class="text-muted" *ngIf="task.model.concernedPerson">Concerne <a [routerLink]="['/persons', task.model.concernedPerson.id]">{{ task.model.concernedPerson | fullname }}</a>.</small>
+      <div class="small text-muted">
+        <div>
+          <span *ngIf="task.model.creator">Créée par {{ task.model.creator.login }}.</span>
+          <span *ngIf="task.model.assignee">Assignée à {{ task.model.assignee.login }}.</span>
+          <span *ngIf="task.model.concernedPerson">Concerne <a [routerLink]="['/persons', task.model.concernedPerson.id]">{{ task.model.concernedPerson | fullname }}</a>.</span>
+        </div>
+        <div>
+          Temps passé:
+          <span *ngIf="task.model.totalSpentTimeInMinutes === 0">{{ task.model.totalSpentTimeInMinutes | duration }}</span>
+          <a href="#" class="spent-times-link" (click)="toggleSpentTimes(task, $event)" *ngIf="task.model.totalSpentTimeInMinutes > 0">{{ task.model.totalSpentTimeInMinutes | duration }}</a>
+          &ndash;
+          <a href="#" class="add-spent-time-link" (click)="toggleAddSpentTime(task, $event)">Ajouter</a>
+          <gl-spent-times *ngIf="task.spentTimesOpened && task.model.totalSpentTimeInMinutes > 0" [taskModel]="task.model" (spentTimeDeleted)="onSpentTimeDeleted($event)"></gl-spent-times>
+          <gl-spent-time-add class="d-block mt-2" *ngIf="task.addSpentTimeOpened" [taskModel]="task.model" (spentTimeAdded)="onSpentTimeAdded($event)" (cancelled)="toggleAddSpentTime(task)"></gl-spent-time-add>
+        </div>
       </div>
       <div class="task-buttons" *ngIf="task.model.status === 'TODO'">
         <button (click)="edit(task, $event)" class="btn btn-secondary btn-sm edit-button"><span class="fa fa-edit"></span></button>
@@ -24,5 +37,5 @@
         <button (click)="resurrect(task, $event)" class="btn btn-outline-info btn-sm resurrect-button"><span class="fa fa-undo"></span></button>
       </div>
     </div>
-  </a>
+  </div>
 </div>

--- a/frontend/src/app/tasks/tasks.component.scss
+++ b/frontend/src/app/tasks/tasks.component.scss
@@ -6,9 +6,9 @@ h2 {
 }
 
 .task-description {
-  white-space: pre-line;
   border-left: 5px solid $gray-400;
   padding-left: 10px;
+  white-space: pre-line;
 }
 
 .task-buttons {


### PR DESCRIPTION
This PR allows showing the total spent time on each task, as well as adding some spent time, and listing the previously entered entries (mainly in order to be able to delete the last one in case of an error).

The main goal is to be able to generate reports at the end of the year (using SQL queries first, and maybe using a dedicated page later). For such a report to be useful, we would have to assign a category to each task. That is not done yet, but it can be done as a separate PR. Sot sure if it's useful to ad a page to create/update new categories though, as this will probably rarely change, and could thus be done directly in the database.

@acrepet there are a few PRs waiting for your tests (cedric has reviewed the code). It would be nice if you could test them so that I can merge them (some of them will have to be reworked because they were developed in parallel).