### PR TITLE
chore: upgrade to ng-bootstrap beta.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "5.0.4",
     "@angular/platform-browser-dynamic": "5.0.4",
     "@angular/router": "5.0.4",
-    "@ng-bootstrap/ng-bootstrap": "^1.0.0-beta.5",
+    "@ng-bootstrap/ng-bootstrap": "^1.0.0-beta.7",
     "bootstrap": "4.0.0-beta.2",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -41,10 +41,6 @@ h2 {
   }
 }
 
-ngb-datepicker-navigation button {
-  border: none;
-}
-
 .deleted {
   color: $danger;
   text-decoration: line-through;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -145,9 +145,9 @@
   dependencies:
     tslib "^1.7.1"
 
-"@ng-bootstrap/ng-bootstrap@^1.0.0-beta.5":
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-1.0.0-beta.5.tgz#da2b9066b3701a284cac5a16168a77def947b4ab"
+"@ng-bootstrap/ng-bootstrap@^1.0.0-beta.7":
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-1.0.0-beta.7.tgz#58bc81f610028f40526529ce40483a95028163b0"
 
 "@ngtools/json-schema@1.1.0", "@ngtools/json-schema@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
I noticed that ng-bootstrap now allows using a type adapter, which would allow us to use an ISO string as the model of our date pickers, instead of having to tranform from/to iso NgbDateStruct. Unfortunately, there is a bug which makes that work only for date pickers, and not for inputs with a datepicker dropdown. The issue is already filed, so the fix should land in the next release.