### PR TITLE
Feat/luxon

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -31,7 +31,6 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
-/typings
 
 # e2e
 /e2e/*.js

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "bootstrap": "4.0.0-beta.2",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",
-    "moment": "^2.18.1",
+    "luxon": "^0.2.9",
     "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"
   },

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -62,7 +62,6 @@ import { TasksComponent } from './tasks/tasks.component';
 import { TasksLayoutComponent } from './tasks-layout/tasks-layout.component';
 import { TasksResolverService } from './tasks-resolver.service';
 import { TaskService } from './task.service';
-import * as moment from 'moment';
 import { NowService } from './now.service';
 import { TasksPageComponent } from './tasks-page/tasks-page.component';
 import { TaskEditComponent } from './task-edit/task-edit.component';
@@ -98,6 +97,7 @@ import { registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
 import { MinValidatorDirective } from './min-validator.directive';
 import { MaxValidatorDirective } from './max-validator.directive';
+import { Settings } from 'luxon';
 import { DurationPipe } from './duration.pipe';
 import { SpentTimesComponent } from './spent-times/spent-times.component';
 import { SpentTimeAddComponent } from './spent-time-add/spent-time-add.component';
@@ -239,6 +239,7 @@ registerLocaleData(localeFr);
 })
 export class AppModule {
   constructor() {
-    moment.locale('fr');
+    Settings.defaultLocale = 'fr';
+    Settings.defaultZoneName = 'Europe/Paris';
   }
 }

--- a/frontend/src/app/cities-upload/cities-upload.component.spec.ts
+++ b/frontend/src/app/cities-upload/cities-upload.component.spec.ts
@@ -6,7 +6,7 @@ import { Subject } from 'rxjs/Subject';
 import { HttpClientModule, HttpEventType, HttpResponse } from '@angular/common/http';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NowService } from '../now.service';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 
 describe('CitiesUploadComponent', () => {
 
@@ -36,8 +36,8 @@ describe('CitiesUploadComponent', () => {
 
     spyOn(component, '_createFileReader').and.returnValue(fileReader);
 
-    const fakeNow = moment();
-    spyOn(nowService, 'now').and.callFake(() => moment(fakeNow));
+    let fakeNow = DateTime.local();
+    spyOn(nowService, 'now').and.callFake(() => fakeNow);
 
     component.upload(fileChangeEvent);
     expect(fileReader.onload).toBeDefined();
@@ -56,7 +56,7 @@ describe('CitiesUploadComponent', () => {
     expect(component.status).toBe('uploading');
 
     // emit first progress event after 5 seconds
-    fakeNow.add(5, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 5 });
     fakeEvents.next({
       type: HttpEventType.UploadProgress,
       loaded: 5,
@@ -68,7 +68,7 @@ describe('CitiesUploadComponent', () => {
     expect(component.progress).toBe(5 / 30);
 
     // emit last progress events
-    fakeNow.add(5, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 5 });
     fakeEvents.next({
       type: HttpEventType.UploadProgress,
       loaded: 10,
@@ -78,15 +78,15 @@ describe('CitiesUploadComponent', () => {
     expect(component.progress).toBe(10 / 30);
     expect(component.status).toBe('processing');
 
-    fakeNow.add(10, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 10 });
     tick(10000);
     expect(component.progress).toBe(20 / 30);
 
-    fakeNow.add(5, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 5 });
     tick(5000);
     expect(component.progress).toBe(25 / 30);
 
-    fakeNow.add(6, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 6 });
     tick(6000);
     expect(component.progress).toBeLessThan(1);
     expect(component.status).toBe('processing');
@@ -114,8 +114,8 @@ describe('CitiesUploadComponent', () => {
     const fileReader = new FileReader();
     spyOn(fileReader, 'readAsText');
     spyOn(component, '_createFileReader').and.returnValue(fileReader);
-    const fakeNow = moment();
-    spyOn(nowService, 'now').and.callFake(() => moment(fakeNow));
+    let fakeNow = DateTime.local();
+    spyOn(nowService, 'now').and.callFake(() => fakeNow);
 
     component.upload(fileChangeEvent);
     expect(fileReader.onload).toBeDefined();
@@ -134,7 +134,7 @@ describe('CitiesUploadComponent', () => {
     expect(component.status).toBe('uploading');
 
     // emit last progress events
-    fakeNow.add(10, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 10 });
     fakeEvents.next({
       type: HttpEventType.UploadProgress,
       loaded: 10,
@@ -144,7 +144,7 @@ describe('CitiesUploadComponent', () => {
     expect(component.progress).toBe(10 / 30);
     expect(component.status).toBe('processing');
 
-    fakeNow.add(15, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 15 });
     tick(15000);
     expect(component.progress).toBe(25 / 30);
 
@@ -155,7 +155,7 @@ describe('CitiesUploadComponent', () => {
     expect(component.status).toBe('done');
 
     // let the fake event observable a chance to realize that the processing is done
-    fakeNow.add(1, 'seconds');
+    fakeNow = fakeNow.plus({ seconds: 1 });
     tick(1000);
   }));
 

--- a/frontend/src/app/now.service.spec.ts
+++ b/frontend/src/app/now.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { NowService } from './now.service';
-import * as moment from 'moment';
 
 describe('NowService', () => {
   beforeEach(() => {
@@ -11,7 +10,7 @@ describe('NowService', () => {
 
   it('should return now', () => {
     const nowService = TestBed.get(NowService);
-    expect(nowService.now().diff(moment.now(), 'seconds')).toBeLessThan(1);
+    expect(Math.abs(nowService.now().diffNow().as('milliseconds'))).toBeLessThan(1000);
     expect(nowService.now()).not.toBe(nowService.now());
   });
 });

--- a/frontend/src/app/now.service.ts
+++ b/frontend/src/app/now.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Moment } from 'moment/moment';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 
 /**
  * A service providing the current time, as a Moment.
@@ -8,7 +7,7 @@ import * as moment from 'moment';
  */
 @Injectable()
 export class NowService {
-  now(): Moment {
-    return moment();
+  now(): DateTime {
+    return DateTime.local();
   }
 }

--- a/frontend/src/app/person-notes/person-notes.component.ts
+++ b/frontend/src/app/person-notes/person-notes.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { UserService } from '../user.service';
 import { PersonNoteService } from '../person-note.service';
 import { ConfirmService } from '../confirm.service';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 import { NoteModel } from '../models/note.model';
 import { NoteEditionEvent } from '../note/note.component';
 import { Observable } from 'rxjs/Observable';
@@ -46,7 +46,7 @@ export class PersonNotesComponent implements OnInit {
     this.editedNote = {
       id: null,
       text: '',
-      creationInstant: moment().toISOString(),
+      creationInstant: DateTime.utc().toISO(),
       creator: this.userService.userEvents.getValue()
     };
     this.notes.push(this.editedNote);

--- a/frontend/src/app/task.service.spec.ts
+++ b/frontend/src/app/task.service.spec.ts
@@ -4,7 +4,6 @@ import { TaskService } from './task.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TaskModel } from './models/task.model';
 import { Observable } from 'rxjs/Observable';
-import * as moment from 'moment';
 import { NowService } from './now.service';
 import { Page } from './models/page';
 import { UserService } from './user.service';
@@ -13,6 +12,7 @@ import { SpentTimeModel } from './models/spent-time.model';
 import { HttpTester } from './http-tester.spec';
 import { UserModel } from './models/user.model';
 import { TaskCategoryModel } from './models/task-category.model';
+import { DateTime } from 'luxon';
 
 describe('TaskService', () => {
   let service: TaskService;
@@ -28,7 +28,7 @@ describe('TaskService', () => {
     service = TestBed.get(TaskService);
     userService = TestBed.get(UserService);
     httpTester = new HttpTester(TestBed.get(HttpTestingController));
-    spyOn(TestBed.get(NowService), 'now').and.callFake(() => moment('2017-08-02T15:30:00'));
+    spyOn(TestBed.get(NowService), 'now').and.callFake(() => DateTime.fromISO('2017-08-02T15:30:00'));
   });
 
   function checkPage(methodToTest: () => Observable<Page<TaskModel>>, expectedUrl: string) {

--- a/frontend/src/app/task.service.ts
+++ b/frontend/src/app/task.service.ts
@@ -27,7 +27,7 @@ export class TaskService {
 
   listUrgent(pageNumber: number): Observable<Page<TaskModel>> {
     return this.http.get<Page<TaskModel>>('/api/tasks', {
-      params: pageParams(pageNumber).set('before', this.nowService.now().add(7, 'd').format('YYYY-MM-DD'))
+      params: pageParams(pageNumber).set('before', this.nowService.now().plus({ days: 7 }).toISODate())
     });
   }
 

--- a/frontend/src/app/tasks-page/tasks-page.component.spec.ts
+++ b/frontend/src/app/tasks-page/tasks-page.component.spec.ts
@@ -8,7 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TaskEventType, TasksComponent } from '../tasks/tasks.component';
 import { FullnamePipe } from '../fullname.pipe';
 import { NowService } from '../now.service';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 import { By } from '@angular/platform-browser';
 import { NgbModule, NgbPagination } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs/Observable';
@@ -100,9 +100,8 @@ describe('TasksPageComponent', () => {
         { provide: ActivatedRoute, useFactory: () => activatedRoute }
       ]
     });
-    moment.locale('fr');
 
-    spyOn(TestBed.get(NowService), 'now').and.callFake(() => moment('2017-08-01T12:30:00'));
+    spyOn(TestBed.get(NowService), 'now').and.callFake(() => DateTime.fromISO('2017-08-01T12:30:00'));
   }));
 
   it('should display tasks in a task list', () => {

--- a/frontend/src/app/tasks/tasks.component.spec.ts
+++ b/frontend/src/app/tasks/tasks.component.spec.ts
@@ -5,7 +5,7 @@ import { TaskModel } from '../models/task.model';
 import { UserModel } from '../models/user.model';
 import { PersonIdentityModel } from '../models/person.model';
 import { FullnamePipe } from '../fullname.pipe';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 import { NowService } from '../now.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TaskService } from '../task.service';
@@ -90,9 +90,8 @@ describe('TasksComponent', () => {
         JwtInterceptorService
       ]
     });
-    moment.locale('fr');
 
-    spyOn(TestBed.get(NowService), 'now').and.callFake(() => moment('2017-08-01T12:30:00'));
+    spyOn(TestBed.get(NowService), 'now').and.callFake(() => DateTime.fromISO('2017-08-01T12:30:00'));
   }));
 
   describe('logic', () => {
@@ -111,10 +110,16 @@ describe('TasksComponent', () => {
       expect(task.relativeDueDate()).toBe('aujourd\'hui');
 
       task.model.dueDate = '2017-08-02';
-      expect(task.relativeDueDate()).toBe('dans un jour');
+      expect(task.relativeDueDate()).toBe('dans 1 jour');
+
+      task.model.dueDate = '2017-08-04';
+      expect(task.relativeDueDate()).toBe('dans 3 jours');
 
       task.model.dueDate = '2017-07-31';
-      expect(task.relativeDueDate()).toBe('il y a un jour');
+      expect(task.relativeDueDate()).toBe('il y a 1 jour');
+
+      task.model.dueDate = '2017-07-29';
+      expect(task.relativeDueDate()).toBe('il y a 3 jours');
     });
 
     it('should compute due date class', () => {

--- a/frontend/src/app/tasks/tasks.component.ts
+++ b/frontend/src/app/tasks/tasks.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TaskModel } from '../models/task.model';
-import * as moment from 'moment';
+import { DateTime } from 'luxon';
 import { NowService } from '../now.service';
 import 'rxjs/add/operator/switchMap';
 import { SpentTimeModel } from '../models/spent-time.model';
@@ -13,18 +13,28 @@ class Task {
   constructor(public model: TaskModel, private nowService: NowService) {}
 
   relativeDueDate(): string {
-    const dueMoment = moment(this.model.dueDate);
+    const dueDateTime = DateTime.fromISO(this.model.dueDate);
     const today = this.nowService.now().startOf('day');
-    if (today.isSame(dueMoment)) {
+    if (today.equals(dueDateTime)) {
       return 'aujourd\'hui';
     }
-    return today.to(dueMoment);
+    const days = dueDateTime.diff(today, ['days']).days;
+    if (days === 0) {
+      return 'aujourd\'hui';
+    }
+    if (days > 0) {
+      return `dans ${days} jour${days > 1 ? 's' : ''}`;
+    }
+    if (days < 0) {
+      const d = Math.abs(days);
+      return `il y a ${d} jour${d > 1 ? 's' : ''}`;
+    }
   }
 
   dueDateClass() {
-    const dueMoment = moment(this.model.dueDate);
+    const dueDateTime = DateTime.fromISO(this.model.dueDate);
     const today = this.nowService.now().startOf('day');
-    const days = dueMoment.diff(today, 'days');
+    const days = dueDateTime.diff(today, ['days']).days;
     if (days < 0) {
       return 'text-danger font-weight-bold';
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "target": "es5",
     "typeRoots": [
+      "typings",
       "node_modules/@types"
     ],
     "lib": [

--- a/frontend/typings/luxon/index.d.ts
+++ b/frontend/typings/luxon/index.d.ts
@@ -1,0 +1,374 @@
+// Type definitions for luxon 0.2
+// Project: https://github.com/moment/luxon#readme
+// Definitions by: Colby DeHart <https://github.com/colbydehart>
+//                 Hyeonseok Yang <https://github.com/FourwingsY>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+// SHOULD BE DELETED ONCE THE TYPINGS ARE FIXED, AND REPLACED BY THE OFFICIAL @types/luxon TYPINGS
+
+/* tslint:disable */
+
+declare module 'luxon' {
+  namespace luxon {
+    type DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+
+    type ZoneOptions = {
+      keepCalendarTime?: boolean;
+    };
+
+    type ToFormatOptions = DateTimeFormatOptions & {
+      round?: boolean;
+    };
+
+    type ISOTimeOptions = {
+      suppressMilliseconds?: boolean;
+      suppressSeconds?: boolean;
+      includeOffset?: boolean;
+    };
+
+    type LocaleOptions = {
+      locale?: string;
+      outputCalendar?: string;
+      numberingSystem?: string;
+    };
+
+    type DateTimeOptions = LocaleOptions & {
+      zone?: string | Zone;
+      setZone?: boolean;
+    };
+
+    type DateTimeJSOptions = LocaleOptions & {
+      zone?: string | Zone;
+    };
+
+    type DateObjectUnits = {
+      year?: number;
+      month?: number;
+      day?: number;
+      ordinal?: number;
+      weekYear?: number;
+      weekNumber?: number;
+      weekday?: number;
+      hour?: number;
+      minute?: number;
+      second?: number;
+      millisecond?: number;
+    };
+
+    type DateObject = DateObjectUnits & LocaleOptions & {
+      zone?: string | Zone;
+    };
+
+    type DiffOptions = {
+      conversionAccuracy?: string;
+    };
+
+    class DateTime {
+      static DATETIME_FULL: DateTimeFormatOptions;
+      static DATETIME_FULL_WITH_SECONDS: DateTimeFormatOptions;
+      static DATEIME_HUGE: DateTimeFormatOptions;
+      static DATEIME_HUGE_WITH_SECONDS: DateTimeFormatOptions;
+      static DATETIME_MED: DateTimeFormatOptions;
+      static DATETIME_MED_WITH_SECONDS: DateTimeFormatOptions;
+      static DATETIME_SHORT: DateTimeFormatOptions;
+      static DATETIME_SHORT_WITH_SECONDS: DateTimeFormatOptions;
+      static DATE_FULL: DateTimeFormatOptions;
+      static DATE_HUGE: DateTimeFormatOptions;
+      static DATE_MED: DateTimeFormatOptions;
+      static DATE_SHORT: DateTimeFormatOptions;
+      static TIME_24_SIMPLE: DateTimeFormatOptions;
+      static TIME_24_WITH_LONG_OFFSET: DateTimeFormatOptions;
+      static TIME_24_WITH_SECONDS: DateTimeFormatOptions;
+      static TIME_24_WITH_SHORT_OFFSET: DateTimeFormatOptions;
+      static TIME_SIMPLE: DateTimeFormatOptions;
+      static TIME_WITH_LONG_OFFSET: DateTimeFormatOptions;
+      static TIME_WITH_SECONDS: DateTimeFormatOptions;
+      static TIME_WITH_SHORT_OFFSET: DateTimeFormatOptions;
+      static fromHTTP(text: string, options?: DateTimeOptions): DateTime;
+      static fromISO(text: string, options?: DateTimeOptions): DateTime;
+      static fromJSDate(
+        date: Date,
+        options?: DateTimeJSOptions
+      ): DateTime;
+      static fromMillis(ms: number, options?: DateTimeOptions): DateTime;
+      static fromObject(obj: DateObject): DateTime;
+      static fromRFC2822(
+        text: string,
+        options?: DateTimeOptions
+      ): DateTime;
+      static fromString(
+        text: string,
+        format: string,
+        options?: DateTimeOptions
+      ): DateTime;
+      static fromStringExplain(
+        text: string,
+        format: string,
+        options?: DateTimeOptions
+      ): object;
+      static invalid(reason: any): DateTime;
+      static local(
+        year?: number,
+        month?: number,
+        day?: number,
+        hour?: number,
+        minute?: number,
+        second?: number,
+        millisecond?: number
+      ): DateTime;
+      static max(...dateTimes: DateTime[]): DateTime | undefined;
+      static min(...dateTimes: DateTime[]): DateTime | undefined;
+      static utc(
+        year?: number,
+        month?: number,
+        day?: number,
+        hour?: number,
+        minute?: number,
+        second?: number,
+        millisecond?: number
+      ): DateTime;
+      day: number;
+      daysInMonth: number;
+      daysInYear: number;
+      hour: number;
+      invalidReason: string;
+      isInDST: boolean;
+      isOffsetFixed: boolean;
+      isValid: boolean;
+      locale: string;
+      millisecond: number;
+      minute: number;
+      month: number;
+      monthLong: string;
+      monthShort: string;
+      numberingSystem: string;
+      offset: number;
+      offsetNameLong: string;
+      offsetNameShort: string;
+      ordinal: number;
+      outputCalendar: string;
+      second: number;
+      weekNumber: number;
+      weekYear: number;
+      weekday: number;
+      weekdayLong: string;
+      weekdayShort: string;
+      year: number;
+      zoneName: string;
+      diff(
+        other: DateTime,
+        unit?: string | string[],
+        options?: DiffOptions
+      ): Duration;
+      diffNow(unit?: string | string[], options?: DiffOptions): Duration;
+      endOf(unit: string): DateTime;
+      equals(other: DateTime): boolean;
+      get(unit: string): number;
+      hasSame(other: DateTime, unit: string): boolean;
+      minus(duration: Duration | number | DurationObject): DateTime;
+      plus(duration: Duration | number | DurationObject): DateTime;
+      reconfigure(properties: LocaleOptions): DateTime;
+      resolvedLocaleOpts(options?: ToFormatOptions): LocaleOptions;
+      set(values: DateObjectUnits): DateTime;
+      setLocale(locale: any): DateTime;
+      setZone(zone: string | Zone, options?: ZoneOptions): DateTime;
+      startOf(unit: string): DateTime;
+      toFormat(format: string, options?: ToFormatOptions): string;
+      toHTTP(): string;
+      toISO(options?: ISOTimeOptions): string;
+      toISODate(): string;
+      toISOTime(options?: ISOTimeOptions): string;
+      toISOWeekDate(): string;
+      toJSDate(): Date;
+      toJSON(): string;
+      toLocal(): DateTime;
+      toLocaleParts(options?: DateTimeFormatOptions): any[];
+      toLocaleString(options?: DateTimeFormatOptions): string;
+      toObject(options?: { includeConfig?: boolean }): DateObject;
+      toRFC2822(): string;
+      toString(): string;
+      toUTC(offset?: number, options?: ZoneOptions): DateTime;
+      until(other: DateTime): Duration;
+      valueOf(): number;
+    }
+
+    type DurationOptions = {
+      locale?: string;
+      numberingSystem?: string;
+      conversionAccuracy?: string;
+    };
+
+    type DurationObjectUnits = {
+      years?: number;
+      months?: number;
+      weeks?: number;
+      days?: number;
+      hours?: number;
+      minutes?: number;
+      seconds?: number;
+      milliseconds?: number;
+    };
+
+    type DurationObject = DurationObjectUnits & DurationOptions;
+
+    class Duration {
+      static fromISO(text: string, options?: DurationOptions): Duration;
+      static fromMillis(
+        count: number,
+        options?: DurationOptions
+      ): Duration;
+      static fromObject(
+        Object: DurationObject
+      ): Duration;
+      static invalid(reason?: string): Duration;
+      days: number;
+      hours: number;
+      invalidReason: string;
+      isValid: boolean;
+      locale: string;
+      milliseconds: number;
+      minutes: number;
+      months: number;
+      numberingSystem: string;
+      seconds: number;
+      weeks: number;
+      years: number;
+      as(unit: string): number;
+      equals(other: Duration): boolean;
+      get(unit: string): number;
+      minus(duration: Duration | number | DurationObject): Duration;
+      negate(): Duration;
+      normalize(): Duration;
+      plus(duration: Duration | number | DurationObject): Duration;
+      reconfigure(objectPattern: DurationOptions): Duration;
+      set(values: DurationObjectUnits): Duration;
+      shiftTo(...units: string[]): Duration;
+      toFormat(format: string, options?: ToFormatOptions): string;
+      toISO(): string;
+      toJSON(): string;
+      toObject(options?: {
+        includeConfig?: boolean;
+      }): DurationObject;
+      toString(): string;
+    }
+
+    type EraLength = 'short' | 'long';
+    type UnitLength = EraLength | 'numeric' | '2-digit' | 'narrow';
+    type UnitOptions = InfoOptions & {
+      numberingSystem?: string;
+      outputCalendar?: string;
+    };
+
+    type InfoOptions = {
+      locale?: string;
+    };
+
+    type Features = {
+      intl: boolean;
+      intlTokens: boolean;
+      timezones: boolean;
+    };
+
+    class Info {
+      static eras(length?: EraLength, options?: InfoOptions): string[];
+      static features(): Features;
+      static hasDST(zone: string | Zone): boolean;
+      static meridiems(options?: InfoOptions): string[];
+      static months(length?: UnitLength, options?: UnitOptions): string[];
+      static monthsFormat(length?: UnitLength, options?: UnitOptions): string[];
+      static weekdays(length?: UnitLength, options?: UnitOptions): string[];
+      static weekdaysFormat(
+        length?: UnitLength,
+        options?: UnitOptions
+      ): string[];
+    }
+
+    type IntervalObject = {
+      start: DateTime;
+      end: DateTime;
+    };
+
+    class Interval {
+      static after(
+        start: DateTime | DateObject | Date,
+        duration: Duration | number | DurationObject
+      ): Interval;
+      static before(
+        end: DateTime | DateObject | Date,
+        duration: Duration | number | DurationObject
+      ): Interval;
+      static fromDateTimes(
+        start: DateTime | DateObject | Date,
+        end: DateTime | DateObject | Date
+      ): Interval;
+      static fromISO(string: string, options?: DateTimeOptions): Interval;
+      static invalid(reason?: string): Interval;
+      static merge(intervals: Interval[]): [Interval];
+      static xor(intervals: Interval[]): [Interval];
+      end: DateTime;
+      invalidReason: string;
+      isValid: boolean;
+      start: DateTime;
+      abutsEnd(other: Interval): boolean;
+      abutsStart(other: Interval): boolean;
+      contains(dateTime: DateTime): boolean;
+      count(unit?: string): number;
+      difference(...intervals: Interval[]): Interval;
+      divideEqually(numberOfParts?: number): Interval[];
+      engulfs(other: Interval): boolean;
+      equals(other: Interval): boolean;
+      hasSame(unit: string): boolean;
+      intersection(other: Interval): Interval;
+      isAfter(dateTime: DateTime): boolean;
+      isBefore(dateTime: DateTime): boolean;
+      isEmpty(): boolean;
+      length(unit?: string): number;
+      overlaps(other: Interval): boolean;
+      set(values: IntervalObject): Interval;
+      splitAt(...dateTimes: DateTime[]): Interval[];
+      splitBy(duration: Duration | DurationObject | number): Interval[];
+      toDuration(
+        unit: string | string[],
+        options?: DiffOptions
+      ): Duration;
+      toFormat(
+        dateFormat: string,
+        options?: {
+          seperator?: string;
+        }
+      ): string;
+      toISO(options?: ISOTimeOptions): string;
+      toString(): string;
+      union(other: Interval): Interval;
+    }
+
+    class Settings {
+      static defaultLocale: string;
+      static defaultNumberingSystem: string;
+      static defaultOutputCalendar: string;
+      static readonly defaultZone: Zone;
+      static defaultZoneName: string;
+      static throwOnInvalid: boolean;
+      static now(): number;
+      static resetCache(): void;
+    }
+
+    type ZoneOffsetOptions = {
+      format?: 'short' | 'long';
+      localeCode?: string;
+    };
+
+    class Zone {
+      static offsetName(ts: number, options?: ZoneOffsetOptions): string;
+      static isValid: boolean;
+      static name: string;
+      static type: string;
+      static universal: boolean;
+      equals(other: Zone): boolean;
+      offset(ts: number): number;
+    }
+  }
+
+  export = luxon;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3326,6 +3326,10 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+luxon@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-0.2.9.tgz#cd8badb9528da07f25b53ca68ccb79d39f08685e"
+
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
@@ -3504,10 +3508,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Replace momentjs by what seems to be its official, more modern replacement (it's hosted at the same place): luxon.

The main advantages are:
 - immutable types, making it safer and cleaner
 - based on Intl (not sure this is an advantage, but it reduces the need for many things to be provided, like locale data and timezones)
 - reduces the gzipped bundle size by 50K because it doesn't import all the locale data like moment does

@cexbrayat you might be interested in reviewing this.

Note that unfortunately, it isn't developed in TypeScript, and doesn't provide its own typings. Typings exist in DefinitelyTyped for a few days now, but they have is fixed in a waiting PR. So, in the meantime, I used my own typings instead of the `@types/luxon` typings.