### PR TITLE
fix: a re-login is not needed anymore to access files

### DIFF
--- a/frontend/src/app/current-user/current-user.service.spec.ts
+++ b/frontend/src/app/current-user/current-user.service.spec.ts
@@ -67,7 +67,7 @@ describe('CurrentUserService', () => {
   it('should retrieve a user if one is stored', () => {
     spyOn(mockLocalStorage, 'getItem').and.returnValue(JSON.stringify(globeUser));
 
-    service.retrieveUser();
+    service._retrieveUser();
 
     expect(service.userEvents.getValue()).toEqual(globeUser);
     expect(jwtInterceptor.token).toBe(globeUser.token);
@@ -76,7 +76,7 @@ describe('CurrentUserService', () => {
   it('should retrieve no user if none stored', () => {
     spyOn(mockLocalStorage, 'getItem');
 
-    service.retrieveUser();
+    service._retrieveUser();
 
     expect(service.userEvents.getValue()).toBeNull();
     expect(jwtInterceptor.token).toBeNull();


### PR DESCRIPTION
Scenario when it failed:

1. Login: the remember me local storage item and the cookie are stored
2. Access a file: we need a cookiefor that because it's not an AJAX request. Everything works fine because the cookie is there.
3. Close the browser
4. Reopen the browser: the local storage item is still there, but the cookie is not
5. Access a file: failure due to the absence of cookie

The cookie is now recreated at startup if the local storage item is there. So the above scenario should now work fine.  