### PR TITLE
chore: use pipeable operators

### DIFF
--- a/frontend/src/app/charge-categories-resolver.service.spec.ts
+++ b/frontend/src/app/charge-categories-resolver.service.spec.ts
@@ -5,6 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ChargeCategoryService } from './charge-category.service';
 import { Observable } from 'rxjs/Observable';
 import { ChargeCategoryModel } from './models/charge-category.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeCategoriesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +15,7 @@ describe('ChargeCategoriesResolverService', () => {
 
   it('should retrieve a category', () => {
     const chargeCategoryService = TestBed.get(ChargeCategoryService);
-    const expectedResults: Observable<Array<ChargeCategoryModel>> = Observable.of([{ id: 42, name: 'rental' }]);
+    const expectedResults: Observable<Array<ChargeCategoryModel>> = of([{ id: 42, name: 'rental' }]);
 
     spyOn(chargeCategoryService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/charge-category-edit/charge-category-edit.component.spec.ts
+++ b/frontend/src/app/charge-category-edit/charge-category-edit.component.spec.ts
@@ -8,8 +8,8 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ChargeCategoryService } from '../charge-category.service';
 import { ErrorService } from '../error.service';
-import { Observable } from 'rxjs/Observable';
 import { ChargeCategoryModel } from '../models/charge-category.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeCategoryEditComponent', () => {
   const fakeRouter = jasmine.createSpyObj('Router', ['navigateByUrl']);
@@ -48,7 +48,7 @@ describe('ChargeCategoryEditComponent', () => {
 
     it('should edit and update an existing charge category', async(() => {
       const chargeCategoryService = TestBed.get(ChargeCategoryService);
-      spyOn(chargeCategoryService, 'update').and.returnValue(Observable.of(chargeCategory));
+      spyOn(chargeCategoryService, 'update').and.returnValue(of(chargeCategory));
       const router = TestBed.get(Router);
       const fixture = TestBed.createComponent(ChargeCategoryEditComponent);
       fixture.detectChanges();
@@ -91,7 +91,7 @@ describe('ChargeCategoryEditComponent', () => {
 
     it('should create and save a new charge category', fakeAsync(() => {
       const chargeCategoryService = TestBed.get(ChargeCategoryService);
-      spyOn(chargeCategoryService, 'create').and.returnValue(Observable.of(null));
+      spyOn(chargeCategoryService, 'create').and.returnValue(of(null));
       const router = TestBed.get(Router);
       const fixture = TestBed.createComponent(ChargeCategoryEditComponent);
 

--- a/frontend/src/app/charge-category-resolver.service.spec.ts
+++ b/frontend/src/app/charge-category-resolver.service.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-
 import { ChargeCategoryResolverService } from './charge-category-resolver.service';
 import { ChargeCategoryService } from './charge-category.service';
 import { HttpClientModule } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { ChargeCategoryModel } from './models/charge-category.model';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeCategoryResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -15,7 +15,7 @@ describe('ChargeCategoryResolverService', () => {
 
   it('should retrieve a type', () => {
     const chargeCategoryService = TestBed.get(ChargeCategoryService);
-    const expectedResult: Observable<ChargeCategoryModel> = Observable.of({ id: 42, name: 'rental' });
+    const expectedResult: Observable<ChargeCategoryModel> = of({ id: 42, name: 'rental' });
 
     spyOn(chargeCategoryService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/charge-type-edit/charge-type-edit.component.spec.ts
+++ b/frontend/src/app/charge-type-edit/charge-type-edit.component.spec.ts
@@ -8,8 +8,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ChargeTypeService } from '../charge-type.service';
 import { ErrorService } from '../error.service';
 import { NgModule } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
 import { ChargeTypeModel } from '../models/charge-type.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeTypeEditComponent', () => {
 
@@ -93,7 +93,7 @@ describe('ChargeTypeEditComponent', () => {
       const chargeTypeService = TestBed.get(ChargeTypeService);
       const router = TestBed.get(Router);
 
-      spyOn(chargeTypeService, 'create').and.returnValue(Observable.of({
+      spyOn(chargeTypeService, 'create').and.returnValue(of({
         id: 42
       }));
 
@@ -193,7 +193,7 @@ describe('ChargeTypeEditComponent', () => {
       const chargeTypeService = TestBed.get(ChargeTypeService);
       const router = TestBed.get(Router);
 
-      spyOn(chargeTypeService, 'update').and.returnValue(Observable.of(null));
+      spyOn(chargeTypeService, 'update').and.returnValue(of(null));
 
       const fixture = TestBed.createComponent(ChargeTypeEditComponent);
       fixture.detectChanges();

--- a/frontend/src/app/charge-type-resolver.service.spec.ts
+++ b/frontend/src/app/charge-type-resolver.service.spec.ts
@@ -6,6 +6,7 @@ import { ChargeTypeModel } from './models/charge-type.model';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { ChargeTypeService } from './charge-type.service';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeTypeResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -15,7 +16,7 @@ describe('ChargeTypeResolverService', () => {
 
   it('should retrieve a type', () => {
     const chargeTypeService = TestBed.get(ChargeTypeService);
-    const expectedResult: Observable<ChargeTypeModel> = Observable.of({ id: 42, name: 'Mortgage' } as ChargeTypeModel);
+    const expectedResult: Observable<ChargeTypeModel> = of({ id: 42, name: 'Mortgage' } as ChargeTypeModel);
 
     spyOn(chargeTypeService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/charge-types-resolver.service.spec.ts
+++ b/frontend/src/app/charge-types-resolver.service.spec.ts
@@ -3,8 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { ChargeTypesResolverService } from './charge-types-resolver.service';
 import { ChargeTypeService } from './charge-type.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 import { ChargeTypeModel } from './models/charge-type.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargeTypesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +14,7 @@ describe('ChargeTypesResolverService', () => {
 
   it('should retrieve a type', () => {
     const chargeTypeService = TestBed.get(ChargeTypeService);
-    const expectedResults = Observable.of([{ id: 42, name: 'mortgage' } as ChargeTypeModel]);
+    const expectedResults = of([{ id: 42, name: 'mortgage' } as ChargeTypeModel]);
 
     spyOn(chargeTypeService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/charges-resolver.service.spec.ts
+++ b/frontend/src/app/charges-resolver.service.spec.ts
@@ -3,8 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { ChargesResolverService } from './charges-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
 import { ChargeService } from './charge.service';
-import { Observable } from 'rxjs/Observable';
 import { ChargeModel } from './models/charge.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ChargesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +14,7 @@ describe('ChargesResolverService', () => {
 
   it('should retrieve the charges of the person stored in the data of the parent route', () => {
     const chargeService = TestBed.get(ChargeService);
-    const expectedResults = Observable.of([{ id: 23 }] as Array<ChargeModel>);
+    const expectedResults = of([{ id: 23 }] as Array<ChargeModel>);
 
     spyOn(chargeService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/cities-upload/cities-upload.component.ts
+++ b/frontend/src/app/cities-upload/cities-upload.component.ts
@@ -1,12 +1,9 @@
 import { Component } from '@angular/core';
 import { SearchCityService } from '../search-city.service';
 import { HttpEventType } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/interval';
-import 'rxjs/add/operator/finally';
-import 'rxjs/add/operator/take';
-import 'rxjs/add/operator/takeWhile';
 import { NowService } from '../now.service';
+import { interval } from 'rxjs/observable/interval';
+import { takeWhile } from 'rxjs/operators';
 
 const ESTIMATED_PROCESSING_TIME_IN_MILLIS = 20000;
 
@@ -50,9 +47,9 @@ export class CitiesUploadComponent {
               // generate fake progress every half-second but
               // - stop before the end, in case the processing time is longer then estimated
               // - stop if we received the response, in case the processing time is shorted than estimated
-              Observable.interval(500)
-                .takeWhile(() => (this.now() - startTime) < estimatedTotalTime && this.progress < 1)
-                .subscribe(() => this.progress = (this.now() - startTime) / estimatedTotalTime);
+              interval(500).pipe(
+                takeWhile(() => (this.now() - startTime) < estimatedTotalTime && this.progress < 1)
+              ).subscribe(() => this.progress = (this.now() - startTime) / estimatedTotalTime);
             }
           }
         }, () => {

--- a/frontend/src/app/confirm.service.ts
+++ b/frontend/src/app/confirm.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ConfirmModalContentComponent } from './confirm-modal-content/confirm-modal-content.component';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/from';
+import { from } from 'rxjs/observable/from';
 
 export interface ConfirmOptions {
   message: string;
@@ -18,6 +18,6 @@ export class ConfirmService {
     const modalRef = this.modalService.open(ConfirmModalContentComponent);
     modalRef.componentInstance.title = options.title || 'Confirmation';
     modalRef.componentInstance.message = options.message;
-    return Observable.from(modalRef.result);
+    return from(modalRef.result);
   }
 }

--- a/frontend/src/app/current-user/current-user.service.ts
+++ b/frontend/src/app/current-user/current-user.service.ts
@@ -4,6 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { UserModel } from '../models/user.model';
 import { Observable } from 'rxjs/Observable';
 import { JwtInterceptorService } from './jwt-interceptor.service';
+import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class CurrentUserService {
@@ -17,8 +18,9 @@ export class CurrentUserService {
   }
 
   authenticate(credentials: { login: string; password: string }) {
-    return this.http.post<UserModel>('/api/authentication', credentials)
-      .do(user => this.storeLoggedInUser(user));
+    return this.http.post<UserModel>('/api/authentication', credentials).pipe(
+      tap(user => this.storeLoggedInUser(user))
+    );
   }
 
   storeLoggedInUser(user: UserModel) {

--- a/frontend/src/app/error.service.ts
+++ b/frontend/src/app/error.service.ts
@@ -3,6 +3,7 @@ import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { FunctionalErrorModel, TechnicalErrorModel } from './models/error.model';
+import { tap } from 'rxjs/operators';
 
 /**
  * Service which acts as an HTTP interceptor, in order to emit HTTP errors (which are then consumed by the
@@ -41,7 +42,9 @@ export class ErrorService implements HttpInterceptor {
   constructor() { }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return next.handle(req).do(null, error => this.handleError(error));
+    return next.handle(req).pipe(
+      tap(null, error => this.handleError(error))
+    );
   }
 
   /**

--- a/frontend/src/app/error/error.component.ts
+++ b/frontend/src/app/error/error.component.ts
@@ -3,7 +3,7 @@ import { ErrorService } from '../error.service';
 import { NavigationEnd, Router } from '@angular/router';
 import { ERRORS, FunctionalErrorModel } from '../models/error.model';
 import { interpolate } from '../utils';
-import 'rxjs/add/operator/filter';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-error',
@@ -26,9 +26,9 @@ export class ErrorComponent implements OnInit {
     this.interceptor.technicalErrors.subscribe(
       err => this.error = { message: err.message, technical: true, status: err.status });
 
-    this.router.events
-      .filter(event => event instanceof NavigationEnd)
-      .subscribe(() => this.error = null);
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd)
+    ).subscribe(() => this.error = null);
   }
 
   private toMessage(error: FunctionalErrorModel) {

--- a/frontend/src/app/income-source-edit/income-source-edit.component.spec.ts
+++ b/frontend/src/app/income-source-edit/income-source-edit.component.spec.ts
@@ -2,7 +2,6 @@ import { async, TestBed } from '@angular/core/testing';
 
 import { IncomeSourceEditComponent } from './income-source-edit.component';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 import { IncomeSourceModel } from '../models/income-source.model';
 import { IncomeSourceService } from '../income-source.service';
 import { FormsModule } from '@angular/forms';
@@ -10,6 +9,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ErrorService } from '../error.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeSourceEditComponent', () => {
 
@@ -93,7 +93,7 @@ describe('IncomeSourceEditComponent', () => {
       const incomeSourceService = TestBed.get(IncomeSourceService);
       const router = TestBed.get(Router);
 
-      spyOn(incomeSourceService, 'create').and.returnValue(Observable.of({
+      spyOn(incomeSourceService, 'create').and.returnValue(of({
         id: 42
       }));
 
@@ -193,7 +193,7 @@ describe('IncomeSourceEditComponent', () => {
       const incomeSourceService = TestBed.get(IncomeSourceService);
       const router = TestBed.get(Router);
 
-      spyOn(incomeSourceService, 'update').and.returnValue(Observable.of(null));
+      spyOn(incomeSourceService, 'update').and.returnValue(of(null));
 
       const fixture = TestBed.createComponent(IncomeSourceEditComponent);
       fixture.detectChanges();

--- a/frontend/src/app/income-source-resolver.service.spec.ts
+++ b/frontend/src/app/income-source-resolver.service.spec.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { IncomeSourceModel } from './models/income-source.model';
 import { IncomeSourceService } from './income-source.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeSourceResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -15,7 +16,7 @@ describe('IncomeSourceResolverService', () => {
 
   it('should retrieve a source', () => {
     const incomeSourceService = TestBed.get(IncomeSourceService);
-    const expectedResult: Observable<IncomeSourceModel> = Observable.of({ id: 42, name: 'Allocations Familiales' } as IncomeSourceModel);
+    const expectedResult: Observable<IncomeSourceModel> = of({ id: 42, name: 'Allocations Familiales' } as IncomeSourceModel);
 
     spyOn(incomeSourceService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/income-sources-resolver.service.spec.ts
+++ b/frontend/src/app/income-sources-resolver.service.spec.ts
@@ -2,9 +2,9 @@ import { TestBed } from '@angular/core/testing';
 
 import { IncomeSourcesResolverService } from './income-sources-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 import { IncomeSourceModel } from './models/income-source.model';
 import { IncomeSourceService } from './income-source.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeSourcesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +14,7 @@ describe('IncomeSourcesResolverService', () => {
 
   it('should retrieve sources', () => {
     const incomeSourceService = TestBed.get(IncomeSourceService);
-    const expectedResults = Observable.of([{ id: 42, name: 'Allocations Familiales' }] as Array<IncomeSourceModel>);
+    const expectedResults = of([{ id: 42, name: 'Allocations Familiales' }] as Array<IncomeSourceModel>);
 
     spyOn(incomeSourceService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/income-type-edit/income-type-edit.component.spec.ts
+++ b/frontend/src/app/income-type-edit/income-type-edit.component.spec.ts
@@ -1,8 +1,5 @@
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { IncomeTypeEditComponent } from './income-type-edit.component';
 import { IncomeSourceTypeModel } from '../models/income-source-type.model';
 import { IncomeSourceTypeService } from '../income-source-type.service';
@@ -11,6 +8,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ErrorService } from '../error.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeTypeEditComponent', () => {
 
@@ -50,7 +48,7 @@ describe('IncomeTypeEditComponent', () => {
 
     it('should edit and update an existing income type', async(() => {
       const incomeSourceTypeService = TestBed.get(IncomeSourceTypeService);
-      spyOn(incomeSourceTypeService, 'update').and.returnValue(Observable.of(incomeType));
+      spyOn(incomeSourceTypeService, 'update').and.returnValue(of(incomeType));
       const router = TestBed.get(Router);
       const fixture = TestBed.createComponent(IncomeTypeEditComponent);
       fixture.detectChanges();
@@ -93,7 +91,7 @@ describe('IncomeTypeEditComponent', () => {
 
     it('should create and save a new income type', fakeAsync(() => {
       const incomeSourceTypeService = TestBed.get(IncomeSourceTypeService);
-      spyOn(incomeSourceTypeService, 'create').and.returnValue(Observable.of(null));
+      spyOn(incomeSourceTypeService, 'create').and.returnValue(of(null));
       const router = TestBed.get(Router);
       const fixture = TestBed.createComponent(IncomeTypeEditComponent);
 

--- a/frontend/src/app/income-type-resolver.service.spec.ts
+++ b/frontend/src/app/income-type-resolver.service.spec.ts
@@ -2,11 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { IncomeTypeResolverService } from './income-type-resolver.service';
 import { IncomeSourceTypeModel } from './models/income-source-type.model';
 import { IncomeSourceTypeService } from './income-source-type.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeTypeResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -16,7 +15,7 @@ describe('IncomeTypeResolverService', () => {
 
   it('should retrieve a type', () => {
     const incomeSourceTypeService = TestBed.get(IncomeSourceTypeService);
-    const expectedResult: Observable<IncomeSourceTypeModel> = Observable.of({ id: 42, type: 'CAF' });
+    const expectedResult: Observable<IncomeSourceTypeModel> = of({ id: 42, type: 'CAF' });
 
     spyOn(incomeSourceTypeService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/income-types-resolver.service.spec.ts
+++ b/frontend/src/app/income-types-resolver.service.spec.ts
@@ -1,11 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { IncomeTypesResolverService } from './income-types-resolver.service';
 import { IncomeSourceTypeModel } from './models/income-source-type.model';
 import { IncomeSourceTypeService } from './income-source-type.service';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomeTypesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -15,7 +14,7 @@ describe('IncomeTypesResolverService', () => {
 
   it('should retrieve a type', () => {
     const incomeSourceTypeService = TestBed.get(IncomeSourceTypeService);
-    const expectedResults: Observable<Array<IncomeSourceTypeModel>> = Observable.of([{ id: 42, type: 'CAF' }]);
+    const expectedResults: Observable<Array<IncomeSourceTypeModel>> = of([{ id: 42, type: 'CAF' }]);
 
     spyOn(incomeSourceTypeService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/incomes-resolver.service.spec.ts
+++ b/frontend/src/app/incomes-resolver.service.spec.ts
@@ -3,8 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { IncomesResolverService } from './incomes-resolver.service';
 import { IncomeService } from './income.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 import { IncomeModel } from './models/income.model';
+import { of } from 'rxjs/observable/of';
 
 describe('IncomesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +14,7 @@ describe('IncomesResolverService', () => {
 
   it('should retrieve the incomes of the person stored in the data of the parent route', () => {
     const incomeService = TestBed.get(IncomeService);
-    const expectedResults = Observable.of([{ id: 23 }] as Array<IncomeModel>);
+    const expectedResults = of([{ id: 23 }] as Array<IncomeModel>);
 
     spyOn(incomeService, 'list').and.returnValue(expectedResults);
 

--- a/frontend/src/app/max-validator.directive.spec.ts
+++ b/frontend/src/app/max-validator.directive.spec.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:deprecation (false positive) */
 import { Component } from '@angular/core';
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, NgForm } from '@angular/forms';

--- a/frontend/src/app/min-validator.directive.spec.ts
+++ b/frontend/src/app/min-validator.directive.spec.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:deprecation (false positive) */
 import { MinValidatorDirective } from './min-validator.directive';
 import { Component } from '@angular/core';
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';

--- a/frontend/src/app/participants-resolver.service.spec.ts
+++ b/frontend/src/app/participants-resolver.service.spec.ts
@@ -3,9 +3,9 @@ import { TestBed } from '@angular/core/testing';
 import { ParticipantsResolverService } from './participants-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
 import { ParticipationService } from './participation.service';
-import { Observable } from 'rxjs/Observable';
 import { PersonIdentityModel } from './models/person.model';
 import { convertToParamMap } from '@angular/router';
+import { of } from 'rxjs/observable/of';
 
 describe('ParticipantsResolverService', () => {
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('ParticipantsResolverService', () => {
 
   it('should resolve the list of participants of an activity type', () => {
     const participationService = TestBed.get(ParticipationService);
-    const participants = Observable.of([{ id: 1 }] as Array<PersonIdentityModel>);
+    const participants = of([{ id: 1 }] as Array<PersonIdentityModel>);
 
     spyOn(participationService, 'listParticipants').and.returnValue(participants);
 

--- a/frontend/src/app/participations-resolver.service.spec.ts
+++ b/frontend/src/app/participations-resolver.service.spec.ts
@@ -4,8 +4,8 @@ import { ParticipationsResolverService } from './participations-resolver.service
 import { ParticipationService } from './participation.service';
 import { HttpClientModule } from '@angular/common/http';
 import { ParticipationModel } from './models/participation.model';
-import { Observable } from 'rxjs/Observable';
 import { PersonModel } from './models/person.model';
+import { of } from 'rxjs/observable/of';
 
 describe('ParticipationsResolverService', () => {
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('ParticipationsResolverService', () => {
 
   it('should resolve the list of participations of a person', () => {
     const participationService = TestBed.get(ParticipationService);
-    const participations = Observable.of([{ id: 1 }] as Array<ParticipationModel>);
+    const participations = of([{ id: 1 }] as Array<ParticipationModel>);
 
     spyOn(participationService, 'list').and.returnValue(participations);
 

--- a/frontend/src/app/password-change/password-change.component.spec.ts
+++ b/frontend/src/app/password-change/password-change.component.spec.ts
@@ -1,13 +1,12 @@
 import { async, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { PasswordChangeComponent } from './password-change.component';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
+import { of } from 'rxjs/observable/of';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 describe('PasswordChangeComponent', () => {
 
@@ -93,8 +92,8 @@ describe('PasswordChangeComponent', () => {
     fixture.detectChanges();
 
     const userService = TestBed.get(CurrentUserService);
-    spyOn(userService, 'checkPassword').and.returnValue(Observable.of(null));
-    spyOn(userService, 'changePassword').and.returnValue(Observable.of(null));
+    spyOn(userService, 'checkPassword').and.returnValue(of(null));
+    spyOn(userService, 'changePassword').and.returnValue(of(null));
 
     const componentInstance = fixture.componentInstance;
     componentInstance.model.oldPassword = 'old';
@@ -117,7 +116,7 @@ describe('PasswordChangeComponent', () => {
     fixture.detectChanges();
 
     const userService = TestBed.get(CurrentUserService);
-    spyOn(userService, 'checkPassword').and.returnValue(Observable.throw(null));
+    spyOn(userService, 'checkPassword').and.returnValue(ErrorObservable.create(null));
     spyOn(userService, 'changePassword');
 
     const componentInstance = fixture.componentInstance;
@@ -140,8 +139,8 @@ describe('PasswordChangeComponent', () => {
     fixture.detectChanges();
 
     const userService = TestBed.get(CurrentUserService);
-    spyOn(userService, 'checkPassword').and.returnValue(Observable.of(null));
-    spyOn(userService, 'changePassword').and.returnValue(Observable.throw(null));
+    spyOn(userService, 'checkPassword').and.returnValue(of(null));
+    spyOn(userService, 'changePassword').and.returnValue(ErrorObservable.create(null));
 
     const componentInstance = fixture.componentInstance;
     componentInstance.model.oldPassword = 'old';

--- a/frontend/src/app/password-change/password-change.component.ts
+++ b/frontend/src/app/password-change/password-change.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { CurrentUserService } from '../current-user/current-user.service';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-password-change',
@@ -20,10 +21,11 @@ export class PasswordChangeComponent {
 
   changePassword() {
     this.passwordChangeFailed = false;
-    this.currentUserService.checkPassword(this.model.oldPassword)
-      .switchMap(() => this.currentUserService.changePassword(this.model.newPassword))
-      .subscribe(
-        () => this.router.navigate(['/']),
-        () => this.passwordChangeFailed = true);
+    this.currentUserService.checkPassword(this.model.oldPassword).pipe(
+      switchMap(() => this.currentUserService.changePassword(this.model.newPassword))
+    ).subscribe(
+      () => this.router.navigate(['/']),
+      () => this.passwordChangeFailed = true
+    );
   }
 }

--- a/frontend/src/app/password-reset/password-reset.component.spec.ts
+++ b/frontend/src/app/password-reset/password-reset.component.spec.ts
@@ -3,11 +3,11 @@ import { async, TestBed } from '@angular/core/testing';
 import { PasswordResetComponent } from './password-reset.component';
 import { UserModel } from '../models/user.model';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 import { UserWithPasswordModel } from '../models/user-with-password.model';
 import { HttpClientModule } from '@angular/common/http';
 import { UserService } from '../user.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 describe('PasswordResetComponent', () => {
   const user: UserModel = {id: 42, login: 'jb', admin: false};
@@ -41,7 +41,7 @@ describe('PasswordResetComponent', () => {
 
     const userService = TestBed.get(UserService);
     const updatedUser = {id: 42, login: 'jb', generatedPassword: 'passw0rd'} as UserWithPasswordModel;
-    spyOn(userService, 'resetPassword').and.returnValue(Observable.of(updatedUser));
+    spyOn(userService, 'resetPassword').and.returnValue(of(updatedUser));
     resetButton.click();
     fixture.detectChanges();
 

--- a/frontend/src/app/person-charge-edit/person-charge-edit.component.spec.ts
+++ b/frontend/src/app/person-charge-edit/person-charge-edit.component.spec.ts
@@ -9,7 +9,7 @@ import { FullnamePipe } from '../fullname.pipe';
 import { NgModule } from '@angular/core';
 import { ChargeService } from '../charge.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonChargeEditComponent', () => {
   const chargeTypes = [
@@ -85,7 +85,7 @@ describe('PersonChargeEditComponent', () => {
       const incomeService = TestBed.get(ChargeService);
       const router = TestBed.get(Router);
 
-      spyOn(incomeService, 'create').and.returnValue(Observable.of({
+      spyOn(incomeService, 'create').and.returnValue(of({
         id: 42
       }));
       spyOn(router, 'navigate');

--- a/frontend/src/app/person-edit/city-typeahead.ts
+++ b/frontend/src/app/person-edit/city-typeahead.ts
@@ -1,14 +1,9 @@
 import { SearchCityService } from '../search-city.service';
 import { CityModel } from '../models/person.model';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
-import 'rxjs/add/operator/switchMap';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/observable/of';
 import { DisplayCityPipe } from '../display-city.pipe';
+import { of } from 'rxjs/observable/of';
+import { catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
 
 export class CityTypeahead {
 
@@ -18,17 +13,20 @@ export class CityTypeahead {
 
   constructor(private searchCityService: SearchCityService, private displayCityPipe: DisplayCityPipe) {
     this.searcher = (text$: Observable<string>) =>
-      text$
-        .filter(query => query.length > 1)
-        .debounceTime(300)
-        .distinctUntilChanged()
-        .switchMap(term =>
-          this.searchCityService.search(term)
-            .do(() => this.searchFailed = false)
-            .catch(() => {
+      text$.pipe(
+        filter(query => query.length > 1),
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap(term =>
+          this.searchCityService.search(term).pipe(
+            tap(() => this.searchFailed = false),
+            catchError(() => {
               this.searchFailed = true;
-              return Observable.of([]);
-            }));
+              return of([]);
+            })
+          )
+        )
+      );
 
     this.formatter = (result: CityModel) => this.displayCityPipe.transform(result);
   }

--- a/frontend/src/app/person-edit/person-edit.component.spec.ts
+++ b/frontend/src/app/person-edit/person-edit.component.spec.ts
@@ -2,8 +2,6 @@ import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { PersonEditComponent } from './person-edit.component';
 import { PersonService } from '../person.service';
 import { CityModel, PersonIdentityModel, PersonModel } from '../models/person.model';
@@ -23,6 +21,8 @@ import { FamilySituationEditComponent } from '../family-situation-edit/family-si
 import { By } from '@angular/platform-browser';
 import { FullnamePipe } from '../fullname.pipe';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { map } from 'rxjs/operators';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonEditComponent', () => {
   const cityModel: CityModel = {
@@ -136,7 +136,7 @@ describe('PersonEditComponent', () => {
 
     it('should edit and update an existing person', () => {
       const personService = TestBed.get(PersonService);
-      spyOn(personService, 'update').and.returnValue(Observable.of(person));
+      spyOn(personService, 'update').and.returnValue(of(person));
       const router = TestBed.get(Router);
       spyOn(router, 'navigate');
       const displayCityPipe = TestBed.get(DisplayCityPipe);
@@ -238,7 +238,7 @@ describe('PersonEditComponent', () => {
       const displayCityPipe = TestBed.get(DisplayCityPipe);
       const fixture = TestBed.createComponent(PersonEditComponent);
       // fake typeahead results
-      fixture.componentInstance.cityTypeahead.searcher = (text: Observable<string>) => text.map(() => []);
+      fixture.componentInstance.cityTypeahead.searcher = (text: Observable<string>) => text.pipe(map(() => []));
 
       fixture.detectChanges();
 
@@ -262,7 +262,7 @@ describe('PersonEditComponent', () => {
     it('should clear the spouse input on blur if not valid anymore', () =>  {
       const fixture = TestBed.createComponent(PersonEditComponent);
       // fake typeahead results
-      fixture.componentInstance.spouseTypeahead.searcher = (text: Observable<string>) => text.map(() => []);
+      fixture.componentInstance.spouseTypeahead.searcher = (text: Observable<string>) => text.pipe(map(() => []));
 
       fixture.detectChanges();
 
@@ -318,7 +318,7 @@ describe('PersonEditComponent', () => {
       const component = fixture.componentInstance;
 
       const personService = TestBed.get(PersonService);
-      spyOn(personService, 'get').and.returnValue(Observable.of({ spouse: { id: 54 } }));
+      spyOn(personService, 'get').and.returnValue(of({ spouse: { id: 54 } }));
 
       component.personForm.get('spouse').setValue({ id: 17, firstName: 'Jackie', lastName: 'Doe' });
       fixture.detectChanges();
@@ -334,7 +334,7 @@ describe('PersonEditComponent', () => {
       const component = fixture.componentInstance;
 
       const personService = TestBed.get(PersonService);
-      spyOn(personService, 'get').and.returnValue(Observable.of({ spouse: null }));
+      spyOn(personService, 'get').and.returnValue(of({ spouse: null }));
 
       component.personForm.get('spouse').setValue({ id: 17, firstName: 'Jackie', lastName: 'Doe' });
       fixture.detectChanges();
@@ -350,7 +350,7 @@ describe('PersonEditComponent', () => {
       const component = fixture.componentInstance;
 
       const personService = TestBed.get(PersonService);
-      spyOn(personService, 'get').and.returnValue(Observable.of({ spouse: { id: 42 } }));
+      spyOn(personService, 'get').and.returnValue(of({ spouse: { id: 42 } }));
 
       component.personForm.get('spouse').setValue({ id: 43, firstName: 'Jane', lastName: 'Doe' });
       fixture.detectChanges();
@@ -380,13 +380,13 @@ describe('PersonEditComponent', () => {
 
     it('should create and save a new person', fakeAsync(() => {
       const personService = TestBed.get(PersonService);
-      spyOn(personService, 'create').and.returnValue(Observable.of({id: 43} as PersonModel));
+      spyOn(personService, 'create').and.returnValue(of({id: 43} as PersonModel));
       const router = TestBed.get(Router);
       spyOn(router, 'navigate');
       const displayCityPipe = TestBed.get(DisplayCityPipe);
       const fixture = TestBed.createComponent(PersonEditComponent);
       // fake typeahead results
-      fixture.componentInstance.cityTypeahead.searcher = (text: Observable<string>) => Observable.of([cityModel]);
+      fixture.componentInstance.cityTypeahead.searcher = (text: Observable<string>) => of([cityModel]);
 
       fixture.detectChanges();
 
@@ -523,7 +523,7 @@ describe('PersonEditComponent', () => {
       maritalStatus.dispatchEvent(new Event('change'));
 
       // trigger city typeahead
-      spyOn(personService, 'get').and.returnValue(Observable.of({ spouse: null }));
+      spyOn(personService, 'get').and.returnValue(of({ spouse: null }));
       spouse.value = 'Jane';
       spouse.dispatchEvent(new Event('input'));
       fixture.detectChanges();

--- a/frontend/src/app/person-files/person-files.component.spec.ts
+++ b/frontend/src/app/person-files/person-files.component.spec.ts
@@ -6,14 +6,13 @@ import { FileModel } from '../models/file.model';
 import { PersonModel } from '../models/person.model';
 import { PersonFileService } from '../person-file.service';
 import { ConfirmService } from '../confirm.service';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { FileSizePipe } from '../file-size.pipe';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs/Subject';
 import { By } from '@angular/platform-browser';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonFilesComponent', () => {
   const person = { id: 42 } as PersonModel;
@@ -56,7 +55,7 @@ describe('PersonFilesComponent', () => {
 
   it('should display files', () => {
     const personFileService = TestBed.get(PersonFileService);
-    spyOn(personFileService, 'list').and.returnValue(Observable.of(files));
+    spyOn(personFileService, 'list').and.returnValue(of(files));
 
     const fixture = TestBed.createComponent(PersonFilesComponent);
     fixture.detectChanges();
@@ -67,7 +66,7 @@ describe('PersonFilesComponent', () => {
 
   it('should display no file message if no files', () => {
     const personFileService = TestBed.get(PersonFileService);
-    spyOn(personFileService, 'list').and.returnValue(Observable.of([]));
+    spyOn(personFileService, 'list').and.returnValue(of([]));
 
     const fixture = TestBed.createComponent(PersonFilesComponent);
     fixture.detectChanges();
@@ -99,9 +98,9 @@ describe('PersonFilesComponent', () => {
     // create component with 2 files
     const personFileService = TestBed.get(PersonFileService);
     const confirmService = TestBed.get(ConfirmService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of('ok'));
-    spyOn(personFileService, 'delete').and.returnValue(Observable.of(null));
-    spyOn(personFileService, 'list').and.returnValues(Observable.of(files), Observable.of([files[1]]));
+    spyOn(confirmService, 'confirm').and.returnValue(of('ok'));
+    spyOn(personFileService, 'delete').and.returnValue(of(null));
+    spyOn(personFileService, 'list').and.returnValues(of(files), of([files[1]]));
 
     const fixture = TestBed.createComponent(PersonFilesComponent);
     fixture.detectChanges();
@@ -119,7 +118,7 @@ describe('PersonFilesComponent', () => {
   it('should upload a file', () => {
     // create component with 1 file
     const personFileService = TestBed.get(PersonFileService);
-    spyOn(personFileService, 'list').and.returnValues(Observable.of([files[0]]), Observable.of([files]));
+    spyOn(personFileService, 'list').and.returnValues(of([files[0]]), of([files]));
 
     const fakeEvents = new Subject<any>();
     spyOn(personFileService, 'create').and.returnValues(fakeEvents);

--- a/frontend/src/app/person-income-edit/person-income-edit.component.spec.ts
+++ b/frontend/src/app/person-income-edit/person-income-edit.component.spec.ts
@@ -4,13 +4,12 @@ import { PersonIncomeEditComponent } from './person-income-edit.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IncomeService } from '../income.service';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { FullnamePipe } from '../fullname.pipe';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonIncomeEditComponent', () => {
   const incomeSources = [
@@ -86,7 +85,7 @@ describe('PersonIncomeEditComponent', () => {
       const incomeService = TestBed.get(IncomeService);
       const router = TestBed.get(Router);
 
-      spyOn(incomeService, 'create').and.returnValue(Observable.of({
+      spyOn(incomeService, 'create').and.returnValue(of({
         id: 42
       }));
       spyOn(router, 'navigate');

--- a/frontend/src/app/person-layout/person-layout.component.spec.ts
+++ b/frontend/src/app/person-layout/person-layout.component.spec.ts
@@ -6,8 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, RouterOutlet } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { FullnamePipe } from '../fullname.pipe';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonLayoutComponent', () => {
   const person = {
@@ -19,7 +18,7 @@ describe('PersonLayoutComponent', () => {
   } as PersonModel;
 
   const activatedRoute = {
-    data: Observable.of({ person }),
+    data: of({ person }),
     snapshot: {}
   };
 

--- a/frontend/src/app/person-layout/person-layout.component.ts
+++ b/frontend/src/app/person-layout/person-layout.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { PersonModel } from '../models/person.model';
-import 'rxjs/add/operator/map';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-person-layout',
@@ -13,6 +13,8 @@ export class PersonLayoutComponent {
   person: PersonModel;
 
   constructor(route: ActivatedRoute) {
-    route.data.map(data => data.person as PersonModel).subscribe(person => this.person = person);
+    route.data.pipe(
+      map(data => data.person as PersonModel)
+    ).subscribe(person => this.person = person);
   }
 }

--- a/frontend/src/app/person-notes/person-notes.component.spec.ts
+++ b/frontend/src/app/person-notes/person-notes.component.spec.ts
@@ -7,15 +7,15 @@ import { NoteComponent } from '../note/note.component';
 import { PersonNoteService } from '../person-note.service';
 import { PersonModel } from '../models/person.model';
 import { NoteModel } from '../models/note.model';
-import { Observable } from 'rxjs/Observable';
 import { ConfirmService } from '../confirm.service';
-import 'rxjs/add/operator/debounceTime';
 import { Subject } from 'rxjs/Subject';
 import { By } from '@angular/platform-browser';
 import { UserModel } from '../models/user.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 describe('PersonNotesComponent', () => {
 
@@ -59,7 +59,7 @@ describe('PersonNotesComponent', () => {
 
   it('should display notes', () => {
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'list').and.returnValue(Observable.of(notes));
+    spyOn(personNoteService, 'list').and.returnValue(of(notes));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -70,7 +70,7 @@ describe('PersonNotesComponent', () => {
 
   it('should display no note message if no notes', () => {
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'list').and.returnValue(Observable.of([]));
+    spyOn(personNoteService, 'list').and.returnValue(of([]));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -103,7 +103,7 @@ describe('PersonNotesComponent', () => {
   it('should disable other notes when editing one', () => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'list').and.returnValue(Observable.of(notes));
+    spyOn(personNoteService, 'list').and.returnValue(of(notes));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -132,9 +132,9 @@ describe('PersonNotesComponent', () => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
     const confirmService = TestBed.get(ConfirmService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of('ok'));
-    spyOn(personNoteService, 'delete').and.returnValue(Observable.of(null));
-    spyOn(personNoteService, 'list').and.returnValues(Observable.of(notes), Observable.of([notes[1]]));
+    spyOn(confirmService, 'confirm').and.returnValue(of('ok'));
+    spyOn(personNoteService, 'delete').and.returnValue(of(null));
+    spyOn(personNoteService, 'list').and.returnValues(of(notes), of([notes[1]]));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -155,9 +155,9 @@ describe('PersonNotesComponent', () => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
     const confirmService = TestBed.get(ConfirmService);
-    spyOn(personNoteService, 'list').and.returnValue(Observable.of(notes));
-    spyOn(personNoteService, 'delete').and.returnValue(Observable.of(null));
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw('nok'));
+    spyOn(personNoteService, 'list').and.returnValue(of(notes));
+    spyOn(personNoteService, 'delete').and.returnValue(of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create('nok'));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -175,8 +175,8 @@ describe('PersonNotesComponent', () => {
   it('should update note', async(() => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'update').and.returnValue(Observable.of(null));
-    spyOn(personNoteService, 'list').and.returnValues(Observable.of(notes), Observable.of(notes));
+    spyOn(personNoteService, 'update').and.returnValue(of(null));
+    spyOn(personNoteService, 'list').and.returnValues(of(notes), of(notes));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -212,8 +212,8 @@ describe('PersonNotesComponent', () => {
   it('should add a note at the end when creating, and remove it when cancelling', () => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'update').and.returnValue(Observable.of(null));
-    spyOn(personNoteService, 'list').and.returnValue(Observable.of(notes));
+    spyOn(personNoteService, 'update').and.returnValue(of(null));
+    spyOn(personNoteService, 'list').and.returnValue(of(notes));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;
@@ -258,8 +258,8 @@ describe('PersonNotesComponent', () => {
     };
 
     const personNoteService = TestBed.get(PersonNoteService);
-    spyOn(personNoteService, 'create').and.returnValue(Observable.of(newNote));
-    spyOn(personNoteService, 'list').and.returnValues(Observable.of(notes), Observable.of([notes[0], notes[1], newNote]));
+    spyOn(personNoteService, 'create').and.returnValue(of(newNote));
+    spyOn(personNoteService, 'list').and.returnValues(of(notes), of([notes[0], notes[1], newNote]));
 
     const fixture = TestBed.createComponent(PersonNotesComponent);
     fixture.componentInstance.person = person;

--- a/frontend/src/app/person-notes/person-notes.component.ts
+++ b/frontend/src/app/person-notes/person-notes.component.ts
@@ -6,11 +6,8 @@ import { NoteModel } from '../models/note.model';
 import { NoteEditionEvent } from '../note/note.component';
 import { Observable } from 'rxjs/Observable';
 import { PersonModel } from '../models/person.model';
-import 'rxjs/add/operator/share';
-import 'rxjs/add/operator/delay';
-import 'rxjs/add/operator/takeUntil';
-import 'rxjs/add/operator/debounceTime';
 import { CurrentUserService } from '../current-user/current-user.service';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-person-notes',
@@ -32,7 +29,7 @@ export class PersonNotesComponent implements OnInit {
               private confirmService: ConfirmService) { }
 
   ngOnInit(): void {
-    // display the spinner after 300ms, unless the notes have loaded before. Note: Observable.delay is untestable,
+    // display the spinner after 300ms, unless the notes have loaded before. Note: delay() is untestable,
     // see https://github.com/angular/angular/issues/10127
     window.setTimeout(() => this.spinnerDisplayed = !this.notes, 300);
 
@@ -77,11 +74,11 @@ export class PersonNotesComponent implements OnInit {
   }
 
   private reloadAfterAction(action: Observable<any>) {
-    action
-      .switchMap(() => this.personNoteService.list(this.person.id))
-      .subscribe(notes => {
-        this.editedNote = null;
-        this.notes = notes;
-      });
+    action.pipe(
+      switchMap(() => this.personNoteService.list(this.person.id))
+    ).subscribe(notes => {
+      this.editedNote = null;
+      this.notes = notes;
+    });
   }
 }

--- a/frontend/src/app/person-participations/person-participations.component.spec.ts
+++ b/frontend/src/app/person-participations/person-participations.component.spec.ts
@@ -3,14 +3,14 @@ import { ParticipationModel } from '../models/participation.model';
 import { ACTIVITY_TYPE_TRANSLATIONS, DisplayActivityTypePipe } from '../display-activity-type.pipe';
 import { PersonModel } from '../models/person.model';
 import { ParticipationService } from '../participation.service';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { ActivatedRoute } from '@angular/router';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { FullnamePipe } from '../fullname.pipe';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs/observable/of';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 describe('PersonParticipationsComponent', () => {
 
@@ -63,7 +63,7 @@ describe('PersonParticipationsComponent', () => {
       socialMediationItem.selected = true;
 
       const participation = { id: 22 } as ParticipationModel;
-      spyOn(participationService, 'create').and.returnValue(Observable.of(participation));
+      spyOn(participationService, 'create').and.returnValue(of(participation));
 
       component.selectionChanged(socialMediationItem);
 
@@ -75,7 +75,7 @@ describe('PersonParticipationsComponent', () => {
       const socialMediationItem: ParticipationItem = component.items.filter(item => item.activityType === 'SOCIAL_MEDIATION')[0];
       socialMediationItem.selected = true;
 
-      spyOn(participationService, 'create').and.returnValue(Observable.throw('error'));
+      spyOn(participationService, 'create').and.returnValue(ErrorObservable.create('error'));
 
       component.selectionChanged(socialMediationItem);
 
@@ -88,7 +88,7 @@ describe('PersonParticipationsComponent', () => {
       const mealItem: ParticipationItem = component.items.filter(item => item.activityType === 'MEAL')[0];
       const participationId = mealItem.id;
       mealItem.selected = false;
-      spyOn(participationService, 'delete').and.returnValue(Observable.of(null));
+      spyOn(participationService, 'delete').and.returnValue(of(null));
 
       component.selectionChanged(mealItem);
 
@@ -100,7 +100,7 @@ describe('PersonParticipationsComponent', () => {
       const mealItem: ParticipationItem = component.items.filter(item => item.activityType === 'MEAL')[0];
       const participationId = mealItem.id;
       mealItem.selected = false;
-      spyOn(participationService, 'delete').and.returnValue(Observable.throw('error'));
+      spyOn(participationService, 'delete').and.returnValue(ErrorObservable.create('error'));
 
       component.selectionChanged(mealItem);
 

--- a/frontend/src/app/person-resolver.service.spec.ts
+++ b/frontend/src/app/person-resolver.service.spec.ts
@@ -1,12 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { PersonResolverService } from './person-resolver.service';
 import { PersonService } from './person.service';
 import { PersonModel } from './models/person.model';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -16,7 +14,7 @@ describe('PersonResolverService', () => {
 
   it('should retrieve a person', () => {
     const personService = TestBed.get(PersonService);
-    const expectedResult = Observable.of({ firstName: 'John', lastName: 'Doe' } as PersonModel);
+    const expectedResult = of({ firstName: 'John', lastName: 'Doe' } as PersonModel);
 
     spyOn(personService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/person-resources/person-resources.component.spec.ts
+++ b/frontend/src/app/person-resources/person-resources.component.spec.ts
@@ -5,13 +5,14 @@ import { IncomeModel } from '../models/income.model';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { ConfirmService } from '../confirm.service';
-import { Observable } from 'rxjs/Observable';
 import { IncomeService } from '../income.service';
 import { HttpClientModule } from '@angular/common/http';
 import { LOCALE_ID } from '@angular/core';
 import { ChargeModel } from '../models/charge.model';
 import { ChargeService } from '../charge.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonResourcesComponent', () => {
   const incomes = [
@@ -114,7 +115,7 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const incomeService = TestBed.get(IncomeService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw(null));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create(null));
     spyOn(incomeService, 'delete');
 
     const nativeElement = fixture.nativeElement;
@@ -133,8 +134,8 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const incomeService = TestBed.get(IncomeService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of(null));
-    spyOn(incomeService, 'delete').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(of(null));
+    spyOn(incomeService, 'delete').and.returnValue(of(null));
 
     const newIncomes = [
       {
@@ -143,7 +144,7 @@ describe('PersonResourcesComponent', () => {
         monthlyAmount: 500
       }
     ] as Array<IncomeModel>;
-    spyOn(incomeService, 'list').and.returnValue(Observable.of(newIncomes));
+    spyOn(incomeService, 'list').and.returnValue(of(newIncomes));
 
     const nativeElement = fixture.nativeElement;
     const deleteButton: HTMLButtonElement = nativeElement.querySelectorAll('.delete-income-button')[0];
@@ -203,7 +204,7 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const chargeService = TestBed.get(IncomeService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw(null));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create(null));
     spyOn(chargeService, 'delete');
 
     const nativeElement = fixture.nativeElement;
@@ -222,8 +223,8 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const chargeService = TestBed.get(ChargeService);
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of(null));
-    spyOn(chargeService, 'delete').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(of(null));
+    spyOn(chargeService, 'delete').and.returnValue(of(null));
 
     const newCharges = [
       {
@@ -232,7 +233,7 @@ describe('PersonResourcesComponent', () => {
         monthlyAmount: 50
       }
     ] as Array<ChargeModel>;
-    spyOn(chargeService, 'list').and.returnValue(Observable.of(newCharges));
+    spyOn(chargeService, 'list').and.returnValue(of(newCharges));
 
     const nativeElement = fixture.nativeElement;
     const deleteButton: HTMLButtonElement = nativeElement.querySelectorAll('.delete-charge-button')[0];

--- a/frontend/src/app/person-resources/person-resources.component.ts
+++ b/frontend/src/app/person-resources/person-resources.component.ts
@@ -6,6 +6,7 @@ import { IncomeService } from '../income.service';
 import { PersonModel } from '../models/person.model';
 import { ChargeModel } from '../models/charge.model';
 import { ChargeService } from '../charge.service';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-person-resources',
@@ -28,17 +29,17 @@ export class PersonResourcesComponent {
   }
 
   deleteIncome(income: IncomeModel) {
-    this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer le revenu ${income.source.name}\u00A0?`})
-      .switchMap(() => this.incomeService.delete(this.person.id, income.id))
-      .switchMap(() => this.incomeService.list(this.person.id))
-      .subscribe(incomes => this.incomes = incomes, () => {});
+    this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer le revenu ${income.source.name}\u00A0?`}).pipe(
+      switchMap(() => this.incomeService.delete(this.person.id, income.id)),
+      switchMap(() => this.incomeService.list(this.person.id))
+    ).subscribe(incomes => this.incomes = incomes, () => {});
   }
 
   deleteCharge(charge: ChargeModel) {
-    this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer la charge ${charge.type.name}\u00A0?`})
-      .switchMap(() => this.chargeService.delete(this.person.id, charge.id))
-      .switchMap(() => this.chargeService.list(this.person.id))
-      .subscribe(charges => this.charges = charges, () => {});
+    this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer la charge ${charge.type.name}\u00A0?`}).pipe(
+      switchMap(() => this.chargeService.delete(this.person.id, charge.id)),
+      switchMap(() => this.chargeService.list(this.person.id))
+    ).subscribe(charges => this.charges = charges, () => {});
   }
 
   totalMonthlyIncomeAmount() {

--- a/frontend/src/app/person/person-typeahead.ts
+++ b/frontend/src/app/person/person-typeahead.ts
@@ -1,10 +1,8 @@
 import { PersonIdentityModel } from '../models/person.model';
 import { Observable } from 'rxjs/Observable';
 import { FullnamePipe } from '../fullname.pipe';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
-import 'rxjs/add/operator/map';
 import { sortBy } from '../utils';
+import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 
 /**
  * Class used to help implementing a person typeahead
@@ -19,10 +17,11 @@ export class PersonTypeahead {
               private fullnamePipe: FullnamePipe) {
     this.persons = sortBy(persons, p => fullnamePipe.transform(p));
     this.searcher = (text$: Observable<string>) =>
-      text$
-        .debounceTime(200)
-        .distinctUntilChanged()
-        .map(term => term === '' ? [] : this.persons.filter(person => this.isPersonAccepted(person, term)).slice(0, 10));
+      text$.pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        map(term => term === '' ? [] : this.persons.filter(person => this.isPersonAccepted(person, term)).slice(0, 10))
+      );
 
     this.formatter = (result: PersonIdentityModel) => this.fullnamePipe.transform(result);
   }

--- a/frontend/src/app/person/person.component.spec.ts
+++ b/frontend/src/app/person/person.component.spec.ts
@@ -16,9 +16,9 @@ import { ConfirmService } from '../confirm.service';
 import { FormsModule } from '@angular/forms';
 import { PersonService } from '../person.service';
 import { FullnamePipe } from '../fullname.pipe';
-import { Observable } from 'rxjs/Observable';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
-import 'rxjs/add/observable/of';
+import { of } from 'rxjs/observable/of';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 describe('PersonComponent', () => {
   const cityModel: CityModel = {
@@ -68,7 +68,7 @@ describe('PersonComponent', () => {
 
   const activatedRoute: any = {
     parent: {
-      data: Observable.of({ person })
+      data: of({ person })
     }
   };
 
@@ -176,8 +176,8 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of('ok'));
-    spyOn(personService, 'delete').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(of('ok'));
+    spyOn(personService, 'delete').and.returnValue(of(null));
     spyOn(router, 'navigate');
 
     expect(fixture.nativeElement.querySelector('#resurrect-person-button')).toBeFalsy();
@@ -197,8 +197,8 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw('nok'));
-    spyOn(personService, 'delete').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create('nok'));
+    spyOn(personService, 'delete').and.returnValue(of(null));
     spyOn(router, 'navigate');
 
     const deleteButton: HTMLButtonElement = fixture.nativeElement.querySelector('#delete-person-button');
@@ -218,8 +218,8 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of('ok'));
-    spyOn(personService, 'resurrect').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(of('ok'));
+    spyOn(personService, 'resurrect').and.returnValue(of(null));
     spyOn(router, 'navigate');
 
     expect(fixture.nativeElement.querySelector('#delete-person-button')).toBeFalsy();
@@ -240,8 +240,8 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw('nok'));
-    spyOn(personService, 'resurrect').and.returnValue(Observable.of(null));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create('nok'));
+    spyOn(personService, 'resurrect').and.returnValue(of(null));
     spyOn(router, 'navigate');
 
     const resurrectButton: HTMLButtonElement = fixture.nativeElement.querySelector('#resurrect-person-button');

--- a/frontend/src/app/person/person.component.ts
+++ b/frontend/src/app/person/person.component.ts
@@ -6,6 +6,7 @@ import { NoteModel } from '../models/note.model';
 import { ConfirmService } from '../confirm.service';
 import { FullnamePipe } from '../fullname.pipe';
 import { PersonService } from '../person.service';
+import { map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-person',
@@ -26,7 +27,9 @@ export class PersonComponent implements OnInit {
               private router: Router) { }
 
   ngOnInit() {
-    this.route.parent.data.map(data => data.person as PersonModel).subscribe(person => {
+    this.route.parent.data.pipe(
+      map(data => data.person as PersonModel)
+    ).subscribe(person => {
       this.person = person;
       this.mapsUrl = this.person.city && this.person.address ? this.createMapsUrl() : null;
     });
@@ -34,16 +37,16 @@ export class PersonComponent implements OnInit {
 
   delete() {
     this.confirmService.confirm(
-      { message: `Voulez-vous vraiment supprimer ${this.fullnamePipe.transform(this.person)}\u00a0?`})
-      .switchMap(() => this.personService.delete(this.person.id))
-      .subscribe(() => this.router.navigate(['/persons']), () => {});
+      { message: `Voulez-vous vraiment supprimer ${this.fullnamePipe.transform(this.person)}\u00a0?`}).pipe(
+      switchMap(() => this.personService.delete(this.person.id))
+    ).subscribe(() => this.router.navigate(['/persons']), () => {});
   }
 
   resurrect() {
     this.confirmService.confirm(
-      { message: `Voulez-vous vraiment annuler la suppression de ${this.fullnamePipe.transform(this.person)}\u00a0?`})
-      .switchMap(() => this.personService.resurrect(this.person.id))
-      .subscribe(() => this.router.navigate(['/persons']), () => {});
+      { message: `Voulez-vous vraiment annuler la suppression de ${this.fullnamePipe.transform(this.person)}\u00a0?`}).pipe(
+      switchMap(() => this.personService.resurrect(this.person.id))
+    ).subscribe(() => this.router.navigate(['/persons']), () => {});
   }
 
   private createMapsUrl() {

--- a/frontend/src/app/persons-resolver.service.spec.ts
+++ b/frontend/src/app/persons-resolver.service.spec.ts
@@ -1,12 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { PersonsResolverService } from './persons-resolver.service';
 import { PersonModel } from './models/person.model';
 import { PersonService } from './person.service';
 import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs/observable/of';
 
 describe('PersonsResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -28,7 +26,7 @@ describe('PersonsResolverService', () => {
   it('should retrieve the active persons', () => {
     const route = routeWithType('active');
     const personService = TestBed.get(PersonService);
-    const expectedResult = Observable.of([{ firstName: 'John', lastName: 'Doe' }] as Array<PersonModel>);
+    const expectedResult = of([{ firstName: 'John', lastName: 'Doe' }] as Array<PersonModel>);
 
     spyOn(personService, 'list').and.returnValue(expectedResult);
 
@@ -41,7 +39,7 @@ describe('PersonsResolverService', () => {
   it('should retrieve the active persons', () => {
     const route = routeWithType('deleted');
     const personService = TestBed.get(PersonService);
-    const expectedResult = Observable.of([{ firstName: 'John', lastName: 'Doe' }] as Array<PersonModel>);
+    const expectedResult = of([{ firstName: 'John', lastName: 'Doe' }] as Array<PersonModel>);
 
     spyOn(personService, 'listDeleted').and.returnValue(expectedResult);
 

--- a/frontend/src/app/search-city.service.ts
+++ b/frontend/src/app/search-city.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpEvent, HttpParams, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/map';
-
 import { CityModel } from './models/person.model';
+import { of } from 'rxjs/observable/of';
 
 @Injectable()
 export class SearchCityService {
@@ -16,7 +14,7 @@ export class SearchCityService {
    */
   search(term: string): Observable<Array<CityModel>> {
     if (term === '') {
-      return Observable.of([]);
+      return of([]);
     }
 
     return this.http.get<Array<CityModel>>('/api/cities', { params : new HttpParams().set('query', term) });

--- a/frontend/src/app/spent-time-add/spent-time-add.component.spec.ts
+++ b/frontend/src/app/spent-time-add/spent-time-add.component.spec.ts
@@ -9,9 +9,8 @@ import { NowService } from '../now.service';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { SpentTimeModel } from '../models/spent-time.model';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { CurrentUserModule } from '../current-user/current-user.module';
+import { of } from 'rxjs/observable/of';
 
 @Component({
   template: `<gl-spent-time-add [taskModel]="task"
@@ -79,7 +78,7 @@ describe('SpentTimeAddComponent', () => {
 
     const taskService = TestBed.get(TaskService);
     const spentTime = { id: 1 } as SpentTimeModel;
-    spyOn(taskService, 'addSpentTime').and.returnValue(Observable.of(spentTime));
+    spyOn(taskService, 'addSpentTime').and.returnValue(of(spentTime));
 
     addButton.click();
     fixture.detectChanges();

--- a/frontend/src/app/spent-time-statistics/spent-time-statistics.component.spec.ts
+++ b/frontend/src/app/spent-time-statistics/spent-time-statistics.component.spec.ts
@@ -6,18 +6,17 @@ import { NowService } from '../now.service';
 import { DateTime } from 'luxon';
 import { TaskService } from '../task.service';
 import { ReactiveFormsModule } from '@angular/forms';
-import 'rxjs/add/observable/of';
 import { ChartComponent } from '../chart/chart.component';
 import { DurationPipe } from '../duration.pipe';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 import { SpentTimeStatisticsModel } from '../models/spent-time-statistics.model';
-import 'rxjs/add/observable/empty';
 import { UserModel } from '../models/user.model';
 import { ChartColor } from 'chart.js';
 import { By } from '@angular/platform-browser';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
 import { CurrentUserModule } from '../current-user/current-user.module';
+import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
 
 class FakeNowService extends NowService {
   now(): DateTime {
@@ -57,7 +56,7 @@ describe('SpentTimeStatisticsComponent', () => {
     });
 
     const taskService = TestBed.get(TaskService);
-    spyOn(taskService, 'spentTimeStatistics').and.returnValue(Observable.empty());
+    spyOn(taskService, 'spentTimeStatistics').and.returnValue(empty());
   });
 
   it('should create form with current month and all users selected', () => {
@@ -104,7 +103,7 @@ describe('SpentTimeStatisticsComponent', () => {
     const statisticsModel: SpentTimeStatisticsModel = {
       statistics: []
     };
-    taskService.spentTimeStatistics.and.returnValue(Observable.of(statisticsModel));
+    taskService.spentTimeStatistics.and.returnValue(of(statisticsModel));
 
     const fixture = TestBed.createComponent(SpentTimeStatisticsComponent);
     const component = fixture.componentInstance;
@@ -142,7 +141,7 @@ describe('SpentTimeStatisticsComponent', () => {
         }
       ]
     };
-    taskService.spentTimeStatistics.and.returnValue(Observable.of(statisticsModel));
+    taskService.spentTimeStatistics.and.returnValue(of(statisticsModel));
 
     const fixture = TestBed.createComponent(SpentTimeStatisticsComponent);
     const component = fixture.componentInstance;
@@ -192,7 +191,7 @@ describe('SpentTimeStatisticsComponent', () => {
         }
       ]
     };
-    taskService.spentTimeStatistics.and.returnValue(Observable.of(statisticsModel));
+    taskService.spentTimeStatistics.and.returnValue(of(statisticsModel));
 
     const fixture = TestBed.createComponent(SpentTimeStatisticsComponent);
     const component = fixture.componentInstance;
@@ -238,7 +237,7 @@ describe('SpentTimeStatisticsComponent', () => {
       ]
     };
 
-    taskService.spentTimeStatistics.and.returnValues(Observable.of(statisticsModel1), Observable.of(statisticsModel2));
+    taskService.spentTimeStatistics.and.returnValues(of(statisticsModel1), of(statisticsModel2));
 
     const fixture = TestBed.createComponent(SpentTimeStatisticsComponent);
     const component = fixture.componentInstance;
@@ -277,7 +276,7 @@ describe('SpentTimeStatisticsComponent', () => {
         }
       ]
     };
-    taskService.spentTimeStatistics.and.returnValue(Observable.of(statisticsModel));
+    taskService.spentTimeStatistics.and.returnValue(of(statisticsModel));
 
     const fixture = TestBed.createComponent(SpentTimeStatisticsComponent);
 

--- a/frontend/src/app/spent-times/spent-times.component.spec.ts
+++ b/frontend/src/app/spent-times/spent-times.component.spec.ts
@@ -5,15 +5,14 @@ import { Component, LOCALE_ID } from '@angular/core';
 import { TaskModel } from '../models/task.model';
 import { SpentTimeEvent } from '../tasks/tasks.component';
 import { TaskService } from '../task.service';
-import { Observable } from 'rxjs/Observable';
 import { SpentTimeModel } from '../models/spent-time.model';
 import { Subject } from 'rxjs/Subject';
 import { HttpClientModule } from '@angular/common/http';
-import 'rxjs/add/observable/of';
 import { DurationPipe } from '../duration.pipe';
 import { NowService } from '../now.service';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import Spy = jasmine.Spy;
+import { of } from 'rxjs/observable/of';
 
 @Component({
   template: `<gl-spent-times [taskModel]="taskModel" (spentTimeDeleted)="storeDeletedSpentTime($event)"></gl-spent-times>`
@@ -43,7 +42,7 @@ describe('SpentTimesComponent', () => {
           id: 1
         }
       ] as Array<SpentTimeModel>;
-      (taskService.listSpentTimes as Spy).and.returnValue(Observable.of(spentTimes));
+      (taskService.listSpentTimes as Spy).and.returnValue(of(spentTimes));
 
       const component = new SpentTimesComponent(taskService);
       component.taskModel = task;
@@ -103,7 +102,7 @@ describe('SpentTimesComponent', () => {
       });
 
       const taskService = TestBed.get(TaskService);
-      spyOn(taskService, 'listSpentTimes').and.returnValue(Observable.of([
+      spyOn(taskService, 'listSpentTimes').and.returnValue(of([
         {
           id: 2,
           minutes: 12,
@@ -118,7 +117,7 @@ describe('SpentTimesComponent', () => {
         }
       ]));
 
-      spyOn(taskService, 'deleteSpentTime').and.returnValue(Observable.of(null));
+      spyOn(taskService, 'deleteSpentTime').and.returnValue(of(null));
 
       fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();

--- a/frontend/src/app/task-categories-resolver.service.spec.ts
+++ b/frontend/src/app/task-categories-resolver.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { TaskCategoriesResolverService } from './task-categories-resolver.service';
 import { TaskService } from './task.service';
 import { TaskCategoryModel } from './models/task-category.model';
+import { of } from 'rxjs/observable/of';
 
 describe('TaskCategoriesResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -17,7 +17,7 @@ describe('TaskCategoriesResolverService', () => {
 
   it('should retrieve task categories', () => {
     const taskService = TestBed.get(TaskService);
-    const expectedResults: Observable<Array<TaskCategoryModel>> = Observable.of([{ id: 42, name: 'Divers' }]);
+    const expectedResults: Observable<Array<TaskCategoryModel>> = of([{ id: 42, name: 'Divers' }]);
 
     taskService.listCategories.and.returnValue(expectedResults);
 

--- a/frontend/src/app/task-edit/task-edit.component.spec.ts
+++ b/frontend/src/app/task-edit/task-edit.component.spec.ts
@@ -10,12 +10,12 @@ import { UserModel } from '../models/user.model';
 import { HttpClientModule } from '@angular/common/http';
 import { TaskService } from '../task.service';
 import { NowService } from '../now.service';
-import { Observable } from 'rxjs/Observable';
 import { TaskModel } from '../models/task.model';
 import { TaskCategoryModel } from '../models/task-category.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 describe('TaskEditComponent', () => {
 
@@ -220,7 +220,7 @@ describe('TaskEditComponent', () => {
 
         const taskService = TestBed.get(TaskService);
         const router = TestBed.get(Router);
-        spyOn(taskService, 'create').and.returnValue(Observable.of({id: 42}));
+        spyOn(taskService, 'create').and.returnValue(of({id: 42}));
         spyOn(router, 'navigate');
 
         saveButton.click();
@@ -273,7 +273,7 @@ describe('TaskEditComponent', () => {
 
         const taskService = TestBed.get(TaskService);
         const router = TestBed.get(Router);
-        spyOn(taskService, 'create').and.returnValue(Observable.of({id: 42}));
+        spyOn(taskService, 'create').and.returnValue(of({id: 42}));
         spyOn(router, 'navigate');
 
         const saveButton = element.querySelector('#save');
@@ -355,7 +355,7 @@ describe('TaskEditComponent', () => {
 
         const taskService = TestBed.get(TaskService);
         const router = TestBed.get(Router);
-        spyOn(taskService, 'update').and.returnValue(Observable.of(null));
+        spyOn(taskService, 'update').and.returnValue(of(null));
         spyOn(router, 'navigate');
 
         const saveButton = element.querySelector('#save');

--- a/frontend/src/app/task-edit/task-edit.component.ts
+++ b/frontend/src/app/task-edit/task-edit.component.ts
@@ -4,8 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { TaskCommand } from '../models/task.command';
 import { PersonIdentityModel } from '../models/person.model';
 import { FullnamePipe } from '../fullname.pipe';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
 import { UserModel } from '../models/user.model';
 import { sortBy } from '../utils';
 import { TaskModel } from '../models/task.model';

--- a/frontend/src/app/task-resolver.service.spec.ts
+++ b/frontend/src/app/task-resolver.service.spec.ts
@@ -3,11 +3,11 @@ import { TestBed } from '@angular/core/testing';
 import { TaskResolverService } from './task-resolver.service';
 import { TaskService } from './task.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 import { TaskModel } from './models/task.model';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { NowService } from './now.service';
 import { CurrentUserModule } from './current-user/current-user.module';
+import { of } from 'rxjs/observable/of';
 
 describe('TaskResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -17,7 +17,7 @@ describe('TaskResolverService', () => {
 
   it('should resolve a task', () => {
     const taskService = TestBed.get(TaskService);
-    const expectedResult = Observable.of({ id: 42 } as TaskModel);
+    const expectedResult = of({ id: 42 } as TaskModel);
 
     spyOn(taskService, 'get').and.returnValue(expectedResult);
 

--- a/frontend/src/app/task.service.ts
+++ b/frontend/src/app/task.service.ts
@@ -11,6 +11,7 @@ import { TaskCategoryModel } from './models/task-category.model';
 import { CurrentUserService } from './current-user/current-user.service';
 import { SpentTimeStatisticsCriteria } from './models/spent-time-statistics.criteria';
 import { SpentTimeStatisticsModel } from './models/spent-time-statistics.model';
+import { map } from 'rxjs/operators';
 
 function pageParams(pageNumber: number): HttpParams {
   return new HttpParams().set('page', pageNumber.toString());
@@ -83,8 +84,9 @@ export class TaskService {
   }
 
   listSpentTimes(taskId: number): Observable<Array<SpentTimeModel>> {
-    return this.http.get<Array<SpentTimeModel>>(`/api/tasks/${taskId}/spent-times`)
-      .map(list => sortBy(list, spentTime => spentTime.creationInstant, true));
+    return this.http.get<Array<SpentTimeModel>>(`/api/tasks/${taskId}/spent-times`).pipe(
+      map(list => sortBy(list, spentTime => spentTime.creationInstant, true))
+    );
   }
 
   deleteSpentTime(taskId: number, spentTimeId: number): Observable<void> {
@@ -96,8 +98,9 @@ export class TaskService {
   }
 
   listCategories(): Observable<Array<TaskCategoryModel>> {
-    return this.http.get<Array<TaskCategoryModel>>('/api/task-categories')
-      .map(categories => sortBy(categories, c => c.name));
+    return this.http.get<Array<TaskCategoryModel>>('/api/task-categories').pipe(
+      map(categories => sortBy(categories, c => c.name))
+    );
   }
 
   spentTimeStatistics(criteria: SpentTimeStatisticsCriteria): Observable<SpentTimeStatisticsModel> {

--- a/frontend/src/app/tasks-page/tasks-page.component.spec.ts
+++ b/frontend/src/app/tasks-page/tasks-page.component.spec.ts
@@ -11,8 +11,6 @@ import { NowService } from '../now.service';
 import { DateTime } from 'luxon';
 import { By } from '@angular/platform-browser';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { TaskService } from '../task.service';
 import { TasksResolverService } from '../tasks-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
@@ -22,6 +20,7 @@ import { DurationPipe } from '../duration.pipe';
 import { UserModel } from '../models/user.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 describe('TasksPageComponent', () => {
   let page: Page<TaskModel>;
@@ -70,7 +69,7 @@ describe('TasksPageComponent', () => {
     };
 
     activatedRoute = {
-      data: Observable.of(data),
+      data: of(data),
       parent: {
         snapshot: {
           data: { }
@@ -207,7 +206,7 @@ describe('TasksPageComponent', () => {
     const taskService = TestBed.get(TaskService);
     const tasksResolverService = TestBed.get(TasksResolverService);
 
-    spyOn(taskService, 'resurrect').and.returnValue(Observable.of(null));
+    spyOn(taskService, 'resurrect').and.returnValue(of(null));
     const newPage: Page<TaskModel> = {
       content: page.content,
       number: 2,
@@ -216,7 +215,7 @@ describe('TasksPageComponent', () => {
       totalPages: 2
     };
 
-    spyOn(tasksResolverService, 'resolve').and.returnValue(Observable.of(newPage));
+    spyOn(tasksResolverService, 'resolve').and.returnValue(of(newPage));
     const router = TestBed.get(Router);
     spyOn(router, 'navigate');
 
@@ -284,7 +283,7 @@ describe('TasksPageComponent', () => {
     const taskService = TestBed.get(TaskService);
     const tasksResolverService = TestBed.get(TasksResolverService);
 
-    spyOn(taskService, taskServiceMethodName).and.returnValue(Observable.of(null));
+    spyOn(taskService, taskServiceMethodName).and.returnValue(of(null));
     const newPage: Page<TaskModel> = {
       content: page.content,
       number: 0,
@@ -293,7 +292,7 @@ describe('TasksPageComponent', () => {
       totalPages: 3
     };
 
-    spyOn(tasksResolverService, 'resolve').and.returnValue(Observable.of(newPage));
+    spyOn(tasksResolverService, 'resolve').and.returnValue(of(newPage));
 
     const task = page.content[0];
 

--- a/frontend/src/app/tasks-page/tasks-page.component.ts
+++ b/frontend/src/app/tasks-page/tasks-page.component.ts
@@ -6,8 +6,8 @@ import { TaskEvent } from '../tasks/tasks.component';
 import { TaskService } from '../task.service';
 import { TasksResolverService } from '../tasks-resolver.service';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/switchMap';
 import { PersonModel } from '../models/person.model';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-tasks-page',
@@ -69,17 +69,17 @@ export class TasksPageComponent implements OnInit {
 
   private handleEvent(action: Observable<void>) {
     const currentPageNumber = this.page.number;
-    action.switchMap(() => this.tasksResolverService.resolve(this.route.snapshot))
-      .subscribe(
-        page => {
-          // maybe we are displaying a page that doesn't exist anymore
-          // so we check and reload with the last page if needed
-          if (currentPageNumber >= page.totalPages && page.totalPages > 0) {
-            this.loadPage(page.totalPages);
-          } else {
-            this.page = page;
-          }
-        },
-        () => {});
+    action.pipe(
+      switchMap(() => this.tasksResolverService.resolve(this.route.snapshot))
+    ).subscribe(page => {
+      // maybe we are displaying a page that doesn't exist anymore
+      // so we check and reload with the last page if needed
+      if (currentPageNumber >= page.totalPages && page.totalPages > 0) {
+        this.loadPage(page.totalPages);
+      } else {
+        this.page = page;
+      }
+    },
+    () => {});
   }
 }

--- a/frontend/src/app/tasks-resolver.service.spec.ts
+++ b/frontend/src/app/tasks-resolver.service.spec.ts
@@ -3,12 +3,12 @@ import { TestBed } from '@angular/core/testing';
 import { TasksResolverService } from './tasks-resolver.service';
 import { TaskService } from './task.service';
 import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 import { HttpClientModule } from '@angular/common/http';
 import { NowService } from './now.service';
 import { TaskModel } from './models/task.model';
 import { Page } from './models/page';
 import { CurrentUserModule } from './current-user/current-user.module';
+import { of } from 'rxjs/observable/of';
 
 describe('TasksResolverService', () => {
   let resolver: TasksResolverService;
@@ -36,7 +36,7 @@ describe('TasksResolverService', () => {
 
   it('should resolve tasks for todo list type', () => {
     const route = routeWithType('todo');
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listTodo').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listTodo).toHaveBeenCalledWith(0);
@@ -44,7 +44,7 @@ describe('TasksResolverService', () => {
 
   it('should resolve tasks for mine list type', () => {
     const route = routeWithType('mine');
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listMine').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listMine).toHaveBeenCalledWith(0);
@@ -52,7 +52,7 @@ describe('TasksResolverService', () => {
 
   it('should resolve tasks for urgent list type', () => {
     const route = routeWithType('urgent');
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listUrgent').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listUrgent).toHaveBeenCalledWith(0);
@@ -60,7 +60,7 @@ describe('TasksResolverService', () => {
 
   it('should resolve tasks for unassigned list type', () => {
     const route = routeWithType('unassigned');
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listUnassigned').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listUnassigned).toHaveBeenCalledWith(0);
@@ -68,7 +68,7 @@ describe('TasksResolverService', () => {
 
   it('should resolve tasks for archived list type', () => {
     const route = routeWithType('archived');
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listArchived').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listArchived).toHaveBeenCalledWith(0);
@@ -83,7 +83,7 @@ describe('TasksResolverService', () => {
         }
       }
     };
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listForPerson').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listForPerson).toHaveBeenCalledWith(42, 0);
@@ -92,7 +92,7 @@ describe('TasksResolverService', () => {
   it('should resolve tasks when page is present', () => {
     const route = routeWithType('archived');
     (route as any).queryParamMap = convertToParamMap({page: '2'});
-    const expected = Observable.of({} as Page<TaskModel>);
+    const expected = of({} as Page<TaskModel>);
     spyOn(taskService, 'listArchived').and.returnValue(expected);
     expect(resolver.resolve(route)).toBe(expected);
     expect(taskService.listArchived).toHaveBeenCalledWith(2);

--- a/frontend/src/app/tasks/tasks.component.spec.ts
+++ b/frontend/src/app/tasks/tasks.component.spec.ts
@@ -18,10 +18,9 @@ import { SpentTimesComponent } from '../spent-times/spent-times.component';
 import { SpentTimeAddComponent } from '../spent-time-add/spent-time-add.component';
 import { DurationPipe } from '../duration.pipe';
 import { SpentTimeModel } from '../models/spent-time.model';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 @Component({
   template: '<gl-tasks [taskModels]="tasks" (taskClicked)="onTaskClicked($event)"></gl-tasks>'
@@ -224,7 +223,7 @@ describe('TasksComponent', () => {
       expect(spentTimesLink).toBeTruthy();
 
       const taskService = TestBed.get(TaskService);
-      spyOn(taskService, 'listSpentTimes').and.returnValue(Observable.of([]));
+      spyOn(taskService, 'listSpentTimes').and.returnValue(of([]));
 
       fixture.nativeElement.querySelector('a.spent-times-link').click();
       fixture.detectChanges();

--- a/frontend/src/app/tasks/tasks.component.ts
+++ b/frontend/src/app/tasks/tasks.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TaskModel } from '../models/task.model';
 import { DateTime } from 'luxon';
 import { NowService } from '../now.service';
-import 'rxjs/add/operator/switchMap';
 import { SpentTimeModel } from '../models/spent-time.model';
 
 class Task {

--- a/frontend/src/app/user-edit/user-edit.component.spec.ts
+++ b/frontend/src/app/user-edit/user-edit.component.spec.ts
@@ -3,7 +3,6 @@ import { async, TestBed } from '@angular/core/testing';
 import { UserEditComponent } from './user-edit.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 import { UserModel } from '../models/user.model';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -12,6 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { ErrorService } from '../error.service';
 import { UserService } from '../user.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { of } from 'rxjs/observable/of';
 
 describe('UserEditComponent', () => {
 
@@ -76,7 +76,7 @@ describe('UserEditComponent', () => {
 
     it('should save the user and display the result', () => {
       const userService = TestBed.get(UserService);
-      spyOn(userService, 'create').and.returnValue(Observable.of({
+      spyOn(userService, 'create').and.returnValue(of({
         login: 'foo',
         generatedPassword: 'passw0rd'
       }));
@@ -175,7 +175,7 @@ describe('UserEditComponent', () => {
       const userService = TestBed.get(UserService);
       const router = TestBed.get(Router);
 
-      spyOn(userService, 'update').and.returnValue(Observable.of(null));
+      spyOn(userService, 'update').and.returnValue(of(null));
       spyOn(router, 'navigate');
 
       const fixture = TestBed.createComponent(UserEditComponent);

--- a/frontend/src/app/user-resolver.service.spec.ts
+++ b/frontend/src/app/user-resolver.service.spec.ts
@@ -2,10 +2,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { UserResolverService } from './user-resolver.service';
 import { UserModel } from './models/user.model';
-import { Observable } from 'rxjs/Observable';
 import { ActivatedRouteSnapshot, convertToParamMap, Params } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { UserService } from './user.service';
+import { of } from 'rxjs/observable/of';
 
 describe('UserResolverService', () => {
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('UserResolverService', () => {
 
   it('should resolve the user', () => {
     const userService = TestBed.get(UserService);
-    const expectedResult = Observable.of({id: 42} as UserModel);
+    const expectedResult = of({id: 42} as UserModel);
     spyOn(userService, 'get').and.returnValue(expectedResult);
 
     const resolver = TestBed.get(UserResolverService);

--- a/frontend/src/app/user.service.ts
+++ b/frontend/src/app/user.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import 'rxjs/add/operator/do';
-
 import { UserModel } from './models/user.model';
 import { Observable } from 'rxjs/Observable';
 import { UserCommand } from './models/user.command';

--- a/frontend/src/app/users-resolver.service.spec.ts
+++ b/frontend/src/app/users-resolver.service.spec.ts
@@ -1,10 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-
 import { UsersResolverService } from './users-resolver.service';
 import { HttpClientModule } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 import { UserService } from './user.service';
+import { of } from 'rxjs/observable/of';
 
 describe('UsersResolverService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -14,7 +12,7 @@ describe('UsersResolverService', () => {
 
   it('should retrieve users', () => {
     const userService = TestBed.get(UserService);
-    const expectedResult = Observable.of([
+    const expectedResult = of([
       { id: 42, login: 'ced', admin: true }
     ]);
     spyOn(userService, 'list').and.returnValue(expectedResult);

--- a/frontend/src/app/users/users.component.spec.ts
+++ b/frontend/src/app/users/users.component.spec.ts
@@ -6,14 +6,13 @@ import { ActivatedRoute } from '@angular/router';
 import { UserModel } from '../models/user.model';
 import { UserService } from '../user.service';
 import { ConfirmService } from '../confirm.service';
-import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { HttpClientModule } from '@angular/common/http';
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { of } from 'rxjs/observable/of';
 
 describe('UsersComponent', () => {
   const users: Array<UserModel> = [
@@ -74,7 +73,7 @@ describe('UsersComponent', () => {
     const confirmService = TestBed.get(ConfirmService);
 
     spyOn(userService, 'delete');
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.throw('nope'));
+    spyOn(confirmService, 'confirm').and.returnValue(ErrorObservable.create('nope'));
 
     const fixture = TestBed.createComponent(UsersComponent);
     fixture.detectChanges();
@@ -88,9 +87,9 @@ describe('UsersComponent', () => {
   it('should delete after confirmation', () => {
     const confirmService = TestBed.get(ConfirmService);
 
-    spyOn(userService, 'delete').and.returnValue(Observable.of(null));
-    spyOn(userService, 'list').and.returnValue(Observable.of(users));
-    spyOn(confirmService, 'confirm').and.returnValue(Observable.of('ok'));
+    spyOn(userService, 'delete').and.returnValue(of(null));
+    spyOn(userService, 'list').and.returnValue(of(users));
+    spyOn(confirmService, 'confirm').and.returnValue(of('ok'));
 
     const fixture = TestBed.createComponent(UsersComponent);
     fixture.detectChanges();

--- a/frontend/src/app/users/users.component.ts
+++ b/frontend/src/app/users/users.component.ts
@@ -3,9 +3,9 @@ import { ActivatedRoute } from '@angular/router';
 import { UserModel } from '../models/user.model';
 import { sortBy } from '../utils';
 import { ConfirmService } from '../confirm.service';
-import 'rxjs/add/operator/switchMap';
 import { UserService } from '../user.service';
 import { CurrentUserService } from '../current-user/current-user.service';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'gl-users',
@@ -26,10 +26,10 @@ export class UsersComponent implements OnInit {
   }
 
   delete(user: UserModel) {
-    this.confirmService.confirm({message: `Voulez-vous vraiment supprimer l\'utilisateur ${user.login}\u00A0?`})
-      .switchMap(() => this.userService.delete(user.id))
-      .switchMap(() => this.userService.list())
-      .subscribe(users => this.users = sortBy(users, u => u.login), () => {});
+    this.confirmService.confirm({message: `Voulez-vous vraiment supprimer l\'utilisateur ${user.login}\u00A0?`}).pipe(
+      switchMap(() => this.userService.delete(user.id)),
+      switchMap(() => this.userService.list())
+    ).subscribe(users => this.users = sortBy(users, u => u.login), () => {});
   }
 
   isCurrentUser(user: UserModel) {

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -117,6 +117,7 @@
       "check-separator",
       "check-type"
     ],
+    "no-import-side-effect": [true, {"ignore-module": "(core-js/.*|zone\\.js/.*)$"}],
     "directive-selector": [
       true,
       "attribute",


### PR DESCRIPTION
It was easier than I thought to migrate: I didn't have inference problems as I did in my early experiments. 

I find the code less readable than before: `of(...)` is leass readable than `Observable.of(...)`.

I chose to use `ErrorObservable.create(...)` rather than `_throw(...)`, which really doesn't look nice, IMO.

The bundle size doesn't seem to be any different. But there is an advantage: it's now impossible to have missing or redundant imports. Missing imports cause a compilation error, and redundant imports, thanks to the strict checks we added before on the cmpiler, are now signalled by an error, too.