### PR TITLE
chore: downgrade flyway because version 5+ doesn't support postgresql 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install language-pack-fr
   - sudo /etc/init.d/postgresql stop
-  - sudo /etc/init.d/postgresql start 9.6
+  - sudo /etc/init.d/postgresql start 9.2
 
 before_script:
   - psql -f backend/database/database.sql -U postgres

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testCompile 'com.ninja-squad:DbSetup:2.1.0'
 
     runtime 'org.postgresql:postgresql:42.1.4'
-    runtime 'org.flywaydb:flyway-core:5.0.3'
+    runtime 'org.flywaydb:flyway-core:4.2.0' // old version needed because Clever cloud only supports postgresql 9.2, and Flyway 5 doesn't support 9.2 anymore
 }
 
 // remove default tasks added by flyway plugin


### PR DESCRIPTION
This should be temporary, bacause clever cloud should migrate to PosgreSQL 10 in 1 or 2 months.

Also use version 9.2 on TravisCI, in order to test that everything works fine with the database we actually use in production.