### PR TITLE
refactor: use a StorageProperties class to load the GCS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ described in [the documentation about default credentials](https://developers.go
 
 To avoid setting a global environment variable, you can instead use this command-line option:
 
-    --globe42.googleCloudStorageCredentialsPath=secrets/google-cloud-storage-dev.json
+    --globe42.googleCloudStorage.credentialsPath=secrets/google-cloud-storage-dev.json
     
 This credentials file is located in [the Ninja Squad Drive](https://drive.google.com/drive/u/1/folders/0B0FLWwufPzrTN1NVTDZJMWZTVXc)
 
@@ -121,6 +121,6 @@ see the [logs console](https://console.clever-cloud.com/organisations/orga_dd753
 ### Google Cloud Storage credentials on CleverCloud
 
 Applications on CleverCloud don't have access to the file system. So, instead of defining an environment variable
-containing the path of the GCS credentials, we use an environment variable, `globe42.googleCloudStorageCredentials`,
+containing the path of the GCS credentials, we use an environment variable, `globe42.googleCloudStorage.credentials`,
 containing the *content* of the production credentials file. 
 

--- a/backend/src/main/java/org/globe42/storage/StorageProperties.java
+++ b/backend/src/main/java/org/globe42/storage/StorageProperties.java
@@ -1,0 +1,40 @@
+package org.globe42.storage;
+
+import java.io.File;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Class containing the globe42 google cloud storage properties
+ * @author JB Nizet
+ */
+@ConfigurationProperties(prefix = "globe42.google-cloud-storage")
+public class StorageProperties {
+    /**
+     * The JSON string containing the credentials. Typically used in production on clever cloud, when there is no file,
+     * but where the JSON can be stored in an environment variable.
+     */
+    private String credentials;
+
+    /**
+     * The path to the JSON file containing the credentials. Only used if {@link #credentials} is not specified.
+     * Typically used in dev mode, where specifying a file path in a command-line property is easier.
+     */
+    private File credentialsPath;
+
+    public String getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(String credentials) {
+        this.credentials = credentials;
+    }
+
+    public File getCredentialsPath() {
+        return credentialsPath;
+    }
+
+    public void setCredentialsPath(File credentialsPath) {
+        this.credentialsPath = credentialsPath;
+    }
+}


### PR DESCRIPTION
This is cleaner than using @Value.
Note that even though the properties must be in lower case with dashes
when reading them, then can be written in camelCase in the yaml file
or in the command-line parameters or environment variables.

Also note that, to be cleaner, I changed the name of the properties:

`globe42.googleCloudStorageCredentials` becomes
`globe42.googleCloudStorage.credentials`, and
`globe42.googleCloudStorageCredentialsPath` becomes
`globe42.googleCloudStorage.credentialsPath`.

In order to avoid forgetting to change the environment when deploying
this new version, I already added the new environment variable in the
Clever Cloud console. We'll just have to remove the old variable when
this change is deployed.