### PR TITLE
chore(lint): add codelyzer rules

### DIFF
--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -130,7 +130,13 @@
       "gl",
       "kebab-case"
     ],
+    "angular-whitespace": [true, "check-semicolon", "check-interpolation"],
     "no-output-on-prefix": true,
+    "banana-in-box": true,
+    "contextual-life-cycle": true,
+    "templates-no-negated-async": true,
+    "template-conditional-complexity": true,
+    "use-view-encapsulation": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,


### PR DESCRIPTION
Adds a few rules:

- angular-whitespace (removed check-pipe as it has a bug with this project)
- banana-in-box
- contextual-life-cycle
- templates-no-negated-async
- template-conditional-complexity
- use-view-encapsulation

I did not add template-cyclomatic-complexity, as it needs a high threshold (25) to pass due to the forms template
that contains a high number of `ngIf`.