### PR TITLE
refactor: use lateinit vars for entity properties that are mandatory

### DIFF
--- a/backend/src/main/kotlin/org/globe42/domain/Charge.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Charge.kt
@@ -23,20 +23,20 @@ class Charge {
      */
     @ManyToOne
     @NotNull
-    var person: Person? = null
+    lateinit var person: Person
 
     /**
      * The type of the charge
      */
     @ManyToOne
     @NotNull
-    var type: ChargeType? = null
+    lateinit var type: ChargeType
 
     /**
      * The monthly amount of the charge
      */
     @NotNull
-    var monthlyAmount: BigDecimal? = null
+    lateinit var monthlyAmount: BigDecimal
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/ChargeCategory.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/ChargeCategory.kt
@@ -32,7 +32,7 @@ class ChargeCategory {
      * The name of the category, as displayed in the application
      */
     @NotEmpty
-    var name: String? = null
+    lateinit var name: String
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/ChargeType.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/ChargeType.kt
@@ -29,14 +29,14 @@ class ChargeType {
      * The name of the charge type (mortgage, electricity, gas, etc.)
      */
     @NotEmpty
-    var name: String? = null
+    lateinit var name: String
 
     /**
      * The type of the income source
      */
     @ManyToOne
     @NotNull
-    var category: ChargeCategory? = null
+    lateinit var category: ChargeCategory
 
     /**
      * The maximum monthly amount (in euros) that the charge can reach. Null if no known maximum.

--- a/backend/src/main/kotlin/org/globe42/domain/City.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/City.kt
@@ -9,7 +9,18 @@ import javax.persistence.Embeddable
  * @author JB Nizet
  */
 @Embeddable
-class City(
-    @field:Length(min = 5, max = 5) @field:Column(name = "postal_code") var code: String,
-    var city: String
-)
+class City {
+    @field:Length(min = 5, max = 5) @field:Column(name = "postal_code") lateinit var code: String
+        private set
+
+    lateinit var city: String
+        private set
+
+    constructor()
+
+    constructor(code: String, city: String) {
+        this.code = code
+        this.city = city
+    }
+}
+

--- a/backend/src/main/kotlin/org/globe42/domain/Country.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Country.kt
@@ -9,16 +9,24 @@ import javax.persistence.Id
  * @author JB Nizet
  */
 @Entity
-class Country(
-
+class Country {
     /**
      * The ISO code of the country
      */
     @Id
-    var id: String,
+    lateinit var id: String
+        private set
 
     /**
      * The French name of the country
      */
-    var name: String
-)
+    lateinit var name: String
+        private set
+
+    constructor()
+
+    constructor(id: String, name: String) {
+        this.id = id
+        this.name = name
+    }
+}

--- a/backend/src/main/kotlin/org/globe42/domain/Income.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Income.kt
@@ -28,20 +28,20 @@ class Income {
      */
     @ManyToOne
     @NotNull
-    var person: Person? = null
+    lateinit var person: Person
 
     /**
      * The source of the income
      */
     @ManyToOne
     @NotNull
-    var source: IncomeSource? = null
+    lateinit var source: IncomeSource
 
     /**
      * The monthly amount of the income
      */
     @NotNull
-    var monthlyAmount: BigDecimal? = null
+    lateinit var monthlyAmount: BigDecimal
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/IncomeSource.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/IncomeSource.kt
@@ -28,14 +28,14 @@ class IncomeSource {
      * The name of the source of income (APL, Agirc/Arrco, etc.)
      */
     @NotEmpty
-    var name: String? = null
+    lateinit var name: String
 
     /**
      * The type of the income source
      */
     @ManyToOne
     @NotNull
-    var type: IncomeSourceType? = null
+    lateinit var type: IncomeSourceType
 
     /**
      * The maximum monthly amount (in euros) that the income source can give as income. Null if no known maximum.

--- a/backend/src/main/kotlin/org/globe42/domain/IncomeSourceType.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/IncomeSourceType.kt
@@ -30,7 +30,7 @@ class IncomeSourceType {
      * The type, as displayed in the application
      */
     @NotEmpty
-    var type: String? = null
+    lateinit var type: String
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/Note.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Note.kt
@@ -20,16 +20,17 @@ class Note {
     var id: Long? = null
 
     @NotEmpty
-    var text: String? = null
+    lateinit var text: String
 
     /**
-     * The user who created the task.
+     * The user who created the note.
      */
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    var creator: User? = null
+    lateinit var creator: User
 
-    var creationInstant: Instant? = null
+    @NotNull
+    var creationInstant = Instant.now()
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/Person.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Person.kt
@@ -31,13 +31,13 @@ class Person {
      * The first name, requested to all persons, and mandatory
      */
     @NotEmpty
-    var firstName: String? = null
+    lateinit var firstName: String
 
     /**
      * The last name, requested to all persons, and mandatory
      */
     @NotEmpty
-    var lastName: String? = null
+    lateinit var lastName: String
 
     /**
      * The birth name, requested to all persons, but not mandatory.
@@ -55,7 +55,7 @@ class Person {
      */
     @NotNull
     @Enumerated(EnumType.STRING)
-    var gender: Gender? = null
+    lateinit var gender: Gender
 
     /**
      * The birth date, requested to all persons, but not mandatory
@@ -291,7 +291,6 @@ class Person {
     }
 
     fun removeIncome(income: Income) {
-        income.person = null
         this.incomes.remove(income)
     }
 
@@ -305,7 +304,6 @@ class Person {
     }
 
     fun removeCharge(charge: Charge) {
-        charge.person = null
         this.charges.remove(charge)
     }
 

--- a/backend/src/main/kotlin/org/globe42/domain/PostalCity.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/PostalCity.kt
@@ -27,13 +27,13 @@ class PostalCity {
     var id: Long? = null
 
     @NotEmpty
-    var postalCode: String? = null
+    lateinit var postalCode: String
 
     /**
      * The city, which is supposed to be in uppercase
      */
     @NotEmpty
-    var city: String? = null
+    lateinit var city: String
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/domain/SpentTime.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/SpentTime.kt
@@ -37,14 +37,14 @@ class SpentTime {
      */
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    var task: Task? = null
+    lateinit var task: Task
 
     /**
      * The user which recorded this time spent on the task (another person might have spent the actual time).
      */
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    var creator: User? = null
+    lateinit var creator: User
 
     /**
      * The time when this spent time was created (might be later than the actual instant when the time was actually

--- a/backend/src/main/kotlin/org/globe42/domain/Task.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/Task.kt
@@ -25,17 +25,17 @@ class Task {
      * The description of the task, which is free text describing what to do.
      */
     @NotEmpty
-    var description: String? = null
+    lateinit var description: String
 
     /**
      * A one-line title shortly describing the task, which appears in the to-do list.
      */
     @NotEmpty
-    var title: String? = null
+    lateinit var title: String
 
     @NotNull
     @ManyToOne
-    var category: TaskCategory? = null
+    lateinit var category: TaskCategory
 
     /**
      * The status of the task. [TaskStatus.TODO] by default
@@ -54,7 +54,7 @@ class Task {
      */
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    var creator: User? = null
+    lateinit var creator: User
 
     /**
      * The user that is assigned to the task.

--- a/backend/src/main/kotlin/org/globe42/domain/TaskCategory.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/TaskCategory.kt
@@ -26,7 +26,7 @@ class TaskCategory {
     var id: Long? = null
 
     @NotEmpty
-    var name: String? = null
+    lateinit var name: String
 
     constructor(id: Long, name: String) {
         this.id = id

--- a/backend/src/main/kotlin/org/globe42/domain/User.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/User.kt
@@ -19,13 +19,13 @@ class User {
     var id: Long? = null
 
     @NotEmpty
-    var login: String? = null
+    lateinit var login: String
 
     /**
      * The salted and hashed password, base64-encoded
      */
     @NotEmpty
-    var password: String? = null
+    lateinit var password: String
 
     /**
      * Indicates that the user is an administrator. An administrator can manage other users, and access information

--- a/backend/src/main/kotlin/org/globe42/domain/WeddingEvent.kt
+++ b/backend/src/main/kotlin/org/globe42/domain/WeddingEvent.kt
@@ -27,14 +27,14 @@ class WeddingEvent {
     @Column(name = "event_date")
     @NotNull
     @Past
-    var date: LocalDate? = null
+    lateinit var date: LocalDate
 
     @NotNull
-    var type: WeddingEventType? = null
+    lateinit var type: WeddingEventType
 
     @ManyToOne
     @NotNull
-    var person: Person? = null
+    lateinit var person: Person
 
     constructor()
 

--- a/backend/src/main/kotlin/org/globe42/web/charges/ChargeCategoryDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/charges/ChargeCategoryDTO.kt
@@ -10,5 +10,5 @@ import org.globe42.domain.IncomeSourceType
  * @author JB Nizet
  */
 data class ChargeCategoryDTO(val id: Long, val name: String) {
-    constructor(category: ChargeCategory) : this(category.id!!, category.name!!)
+    constructor(category: ChargeCategory) : this(category.id!!, category.name)
 }

--- a/backend/src/main/kotlin/org/globe42/web/charges/ChargeController.kt
+++ b/backend/src/main/kotlin/org/globe42/web/charges/ChargeController.kt
@@ -57,7 +57,7 @@ class ChargeController(
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@PathVariable("personId") personId: Long, @PathVariable("chargeId") chargeId: Long) {
         chargeDao.findById(chargeId).ifPresent { charge ->
-            if (charge.person!!.id != personId) {
+            if (charge.person.id != personId) {
                 throw NotFoundException("Charge with ID $chargeId does not belong to person $personId")
             }
             chargeDao.delete(charge)

--- a/backend/src/main/kotlin/org/globe42/web/charges/ChargeDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/charges/ChargeDTO.kt
@@ -9,5 +9,5 @@ import java.math.BigDecimal
  */
 data class ChargeDTO(val id: Long, val type: ChargeTypeDTO, val monthlyAmount: BigDecimal?) {
 
-    constructor(charge: Charge) : this(charge.id!!, ChargeTypeDTO(charge.type!!), charge.monthlyAmount)
+    constructor(charge: Charge) : this(charge.id!!, ChargeTypeDTO(charge.type), charge.monthlyAmount)
 }

--- a/backend/src/main/kotlin/org/globe42/web/charges/ChargeTypeDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/charges/ChargeTypeDTO.kt
@@ -18,8 +18,8 @@ data class ChargeTypeDTO(
 
     constructor(chargeType: ChargeType) : this(
         chargeType.id!!,
-        chargeType.name!!,
-        ChargeCategoryDTO(chargeType.category!!),
+        chargeType.name,
+        ChargeCategoryDTO(chargeType.category),
         chargeType.maxMonthlyAmount
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/incomes/IncomeController.kt
+++ b/backend/src/main/kotlin/org/globe42/web/incomes/IncomeController.kt
@@ -57,7 +57,7 @@ class IncomeController(
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@PathVariable("personId") personId: Long, @PathVariable("incomeId") incomeId: Long) {
         incomeDao.findById(incomeId).ifPresent { income ->
-            if (income.person!!.id != personId) {
+            if (income.person.id != personId) {
                 throw NotFoundException("Income with ID $incomeId does not belong to person $personId")
             }
             incomeDao.delete(income)

--- a/backend/src/main/kotlin/org/globe42/web/incomes/IncomeDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/incomes/IncomeDTO.kt
@@ -13,5 +13,5 @@ data class IncomeDTO(
     val monthlyAmount: BigDecimal
 ) {
 
-    constructor(income: Income) : this(income.id!!, IncomeSourceDTO(income.source!!), income.monthlyAmount!!)
+    constructor(income: Income) : this(income.id!!, IncomeSourceDTO(income.source), income.monthlyAmount)
 }

--- a/backend/src/main/kotlin/org/globe42/web/incomes/IncomeSourceDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/incomes/IncomeSourceDTO.kt
@@ -18,8 +18,8 @@ data class IncomeSourceDTO(
 
     constructor(incomeSource: IncomeSource) : this(
         incomeSource.id!!,
-        incomeSource.name!!,
-        IncomeSourceTypeDTO(incomeSource.type!!),
+        incomeSource.name,
+        IncomeSourceTypeDTO(incomeSource.type),
         incomeSource.maxMonthlyAmount
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/incomes/IncomeSourceTypeDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/incomes/IncomeSourceTypeDTO.kt
@@ -15,6 +15,6 @@ data class IncomeSourceTypeDTO(
 
     constructor(incomeSourceType: IncomeSourceType) : this(
         incomeSourceType.id!!,
-        incomeSourceType.type!!
+        incomeSourceType.type
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/persons/CityDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/CityDTO.kt
@@ -13,5 +13,5 @@ data class CityDTO(
     val city: String
 ) {
     constructor(city: City) : this(city.code, city.city)
-    constructor(city: PostalCity) : this(city.postalCode!!, city.city!!)
+    constructor(city: PostalCity) : this(city.postalCode, city.city)
 }

--- a/backend/src/main/kotlin/org/globe42/web/persons/NoteDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/NoteDTO.kt
@@ -17,8 +17,8 @@ data class NoteDTO(
 
     constructor(note: Note) : this(
         note.id!!,
-        note.text!!,
-        UserDTO(note.creator!!),
-        note.creationInstant!!
+        note.text,
+        UserDTO(note.creator),
+        note.creationInstant
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/persons/PersonController.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/PersonController.kt
@@ -144,7 +144,7 @@ class PersonController(
     }
 
     private fun mediationCodeLetter(person: Person): Char {
-        val letter = Character.toUpperCase(person.lastName!![0])
+        val letter = Character.toUpperCase(person.lastName[0])
         return if (letter < 'A' || letter > 'Z') 'Z' else letter
     }
 

--- a/backend/src/main/kotlin/org/globe42/web/persons/PersonDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/PersonDTO.kt
@@ -52,7 +52,7 @@ data class PersonDTO(
         email = person.email,
         adherent = person.adherent,
         entryDate = person.entryDate,
-        gender = person.gender!!,
+        gender = person.gender,
         phoneNumber = person.phoneNumber,
         mediationEnabled = person.mediationEnabled,
         firstMediationAppointmentDate = person.firstMediationAppointmentDate,

--- a/backend/src/main/kotlin/org/globe42/web/persons/PersonIdentityDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/PersonIdentityDTO.kt
@@ -16,8 +16,8 @@ data class PersonIdentityDTO(
 
     constructor(person: Person) : this(
         person.id!!,
-        person.firstName!!,
-        person.lastName!!,
+        person.firstName,
+        person.lastName,
         person.nickName,
         // we hide the mediation code if mediation is disabled
         if (person.mediationEnabled) person.mediationCode else null

--- a/backend/src/main/kotlin/org/globe42/web/persons/PersonNoteController.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/PersonNoteController.kt
@@ -8,7 +8,6 @@ import org.globe42.web.security.CurrentUser
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import java.time.Instant
 import java.util.*
 import java.util.stream.Collectors
 import javax.transaction.Transactional
@@ -42,7 +41,6 @@ class PersonNoteController(
         val person = personDao.findById(personId).orElseThrow(::NotFoundException)
 
         val note = Note()
-        note.creationInstant = Instant.now()
         note.creator = userDao.getOne(currentUser.userId!!)
         note.text = command.text
         person.addNote(note)

--- a/backend/src/main/kotlin/org/globe42/web/persons/WeddingEventDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/persons/WeddingEventDTO.kt
@@ -16,7 +16,7 @@ data class WeddingEventDTO(
 
     constructor(event: WeddingEvent) : this(
         event.id!!,
-        event.date!!,
-        event.type!!
+        event.date,
+        event.type
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/security/AuthenticatedUserDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/security/AuthenticatedUserDTO.kt
@@ -13,5 +13,5 @@ data class AuthenticatedUserDTO(
     val token: String
 ) {
 
-    constructor(user: User, token: String) : this(user.id!!, user.login!!, user.admin, token)
+    constructor(user: User, token: String) : this(user.id!!, user.login, user.admin, token)
 }

--- a/backend/src/main/kotlin/org/globe42/web/security/CurrentUser.kt
+++ b/backend/src/main/kotlin/org/globe42/web/security/CurrentUser.kt
@@ -13,7 +13,7 @@ import org.springframework.web.context.WebApplicationContext
 @Component
 class CurrentUser {
     /**
-     * Sets the current user ID. Intentionally only visible to classes in the same package
+     * Gets/Sets the current user ID. Setter intentionally only visible to classes in the same package.
      */
     var userId: Long? = null
         internal set

--- a/backend/src/main/kotlin/org/globe42/web/tasks/SpentTimeDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/tasks/SpentTimeDTO.kt
@@ -18,7 +18,7 @@ data class SpentTimeDTO(
     constructor(spentTime: SpentTime) : this(
         spentTime.id!!,
         spentTime.minutes,
-        UserDTO(spentTime.creator!!),
+        UserDTO(spentTime.creator),
         spentTime.creationInstant
     )
 }

--- a/backend/src/main/kotlin/org/globe42/web/tasks/TaskCategoryDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/tasks/TaskCategoryDTO.kt
@@ -7,5 +7,5 @@ import org.globe42.domain.TaskCategory
  * @author JB Nizet
  */
 data class TaskCategoryDTO(val id: Long, val name: String) {
-    constructor(category: TaskCategory) : this(category.id!!, category.name!!)
+    constructor(category: TaskCategory) : this(category.id!!, category.name)
 }

--- a/backend/src/main/kotlin/org/globe42/web/tasks/TaskDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/tasks/TaskDTO.kt
@@ -25,12 +25,12 @@ data class TaskDTO(
 
     constructor(task: Task) : this(
         task.id!!,
-        task.description!!,
-        task.title!!,
-        TaskCategoryDTO(task.category!!),
+        task.description,
+        task.title,
+        TaskCategoryDTO(task.category),
         task.status,
         task.dueDate,
-        UserDTO(task.creator!!),
+        UserDTO(task.creator),
         task.assignee?.let { UserDTO(it) },
         task.concernedPerson?.let { PersonIdentityDTO(it) },
         task.totalSpentTimeInMinutes

--- a/backend/src/main/kotlin/org/globe42/web/users/CurrentUserDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/users/CurrentUserDTO.kt
@@ -7,5 +7,5 @@ import org.globe42.domain.User
  * @author JB Nizet
  */
 data class CurrentUserDTO(val id: Long, val login: String, val admin: Boolean) {
-    constructor(user: User) : this(user.id!!, user.login!!, user.admin)
+    constructor(user: User) : this(user.id!!, user.login, user.admin)
 }

--- a/backend/src/main/kotlin/org/globe42/web/users/UserDTO.kt
+++ b/backend/src/main/kotlin/org/globe42/web/users/UserDTO.kt
@@ -7,5 +7,5 @@ import org.globe42.domain.User
  * @author JB Nizet
  */
 data class UserDTO(val id: Long, val login: String, val admin: Boolean) {
-    constructor(user: User) : this(user.id!!, user.login!!, user.admin)
+    constructor(user: User) : this(user.id!!, user.login, user.admin)
 }

--- a/backend/src/test/kotlin/org/globe42/web/charges/ChargeControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/charges/ChargeControllerMvcTest.kt
@@ -59,8 +59,8 @@ class ChargeControllerMvcTest {
         mvc.perform(get("/api/persons/{personId}/charges", person.id))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(charge.id!!))
-            .andExpect(jsonPath("$[0].monthlyAmount").value(charge.monthlyAmount!!.toDouble()))
-            .andExpect(jsonPath("$[0].type.id").value(charge.type!!.id!!.toInt()))
+            .andExpect(jsonPath("$[0].monthlyAmount").value(charge.monthlyAmount.toDouble()))
+            .andExpect(jsonPath("$[0].type.id").value(charge.type.id!!.toInt()))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/globe42/web/charges/ChargeControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/charges/ChargeControllerTest.kt
@@ -53,7 +53,7 @@ class ChargeControllerTest : BaseTest() {
 
         assertThat(result).hasSize(1)
         assertThat(result[0].id).isEqualTo(charge.id)
-        assertThat(result[0].type.id).isEqualTo(charge.type!!.id)
+        assertThat(result[0].type.id).isEqualTo(charge.type.id)
         assertThat(result[0].monthlyAmount).isEqualTo(charge.monthlyAmount)
     }
 

--- a/backend/src/test/kotlin/org/globe42/web/charges/ChargeTypeControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/charges/ChargeTypeControllerMvcTest.kt
@@ -56,9 +56,9 @@ class ChargeTypeControllerMvcTest {
         mvc.perform(get("/api/charge-types"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(42))
-            .andExpect(jsonPath("$[0].name").value(chargeType.name!!))
-            .andExpect(jsonPath("$[0].category.id").value(chargeType.category!!.id!!))
-            .andExpect(jsonPath("$[0].category.name").value(chargeType.category!!.name!!))
+            .andExpect(jsonPath("$[0].name").value(chargeType.name))
+            .andExpect(jsonPath("$[0].category.id").value(chargeType.category.id!!))
+            .andExpect(jsonPath("$[0].category.name").value(chargeType.category.name))
             .andExpect(jsonPath("$[0].maxMonthlyAmount").value(chargeType.maxMonthlyAmount!!.toDouble()))
     }
 
@@ -75,7 +75,7 @@ class ChargeTypeControllerMvcTest {
     fun `should create`() {
         val command = createCommand()
         whenever(mockChargeTypeDao.save(any<ChargeType>())).thenReturn(chargeType)
-        whenever(mockChargeCategoryDao.findById(command.categoryId)).thenReturn(Optional.of(chargeType.category!!))
+        whenever(mockChargeCategoryDao.findById(command.categoryId)).thenReturn(Optional.of(chargeType.category))
 
         mvc.perform(
             post("/api/charge-types")
@@ -91,7 +91,7 @@ class ChargeTypeControllerMvcTest {
         val command = createCommand()
 
         whenever(mockChargeTypeDao.findById(chargeType.id!!)).thenReturn(Optional.of(chargeType))
-        whenever(mockChargeCategoryDao.findById(command.categoryId)).thenReturn(Optional.of(chargeType.category!!))
+        whenever(mockChargeCategoryDao.findById(command.categoryId)).thenReturn(Optional.of(chargeType.category))
 
         mvc.perform(
             put("/api/charge-types/{sourceId}", chargeType.id)

--- a/backend/src/test/kotlin/org/globe42/web/charges/ChargeTypeControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/charges/ChargeTypeControllerTest.kt
@@ -58,8 +58,8 @@ class ChargeTypeControllerTest : BaseTest() {
         val (id, name, category, maxMonthlyAmount) = result[0]
         assertThat(id).isEqualTo(chargeType.id)
         assertThat(name).isEqualTo(chargeType.name)
-        assertThat(category.id).isEqualTo(chargeType.category!!.id)
-        assertThat(category.name).isEqualTo(chargeType.category!!.name)
+        assertThat(category.id).isEqualTo(chargeType.category.id)
+        assertThat(category.name).isEqualTo(chargeType.category.name)
         assertThat(maxMonthlyAmount).isEqualTo(chargeType.maxMonthlyAmount)
         assertThat(id).isEqualTo(chargeType.id)
     }
@@ -172,7 +172,7 @@ class ChargeTypeControllerTest : BaseTest() {
 
     private fun assertChargeTypeEqualsCommand(source: ChargeType, command: ChargeTypeCommandDTO) {
         assertThat(source.name).isEqualTo(command.name)
-        assertThat(source.category!!.id!!).isEqualTo(command.categoryId)
+        assertThat(source.category.id!!).isEqualTo(command.categoryId)
         assertThat(source.maxMonthlyAmount).isEqualTo(command.maxMonthlyAmount)
     }
 }

--- a/backend/src/test/kotlin/org/globe42/web/incomes/IncomeControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/incomes/IncomeControllerMvcTest.kt
@@ -60,8 +60,8 @@ class IncomeControllerMvcTest {
         mvc.perform(get("/api/persons/{personId}/incomes", person.id))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(income.id!!.toInt()))
-            .andExpect(jsonPath("$[0].monthlyAmount").value(income.monthlyAmount!!.toDouble()))
-            .andExpect(jsonPath("$[0].source.id").value(income.source!!.id!!.toInt()))
+            .andExpect(jsonPath("$[0].monthlyAmount").value(income.monthlyAmount.toDouble()))
+            .andExpect(jsonPath("$[0].source.id").value(income.source.id!!.toInt()))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/globe42/web/incomes/IncomeControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/incomes/IncomeControllerTest.kt
@@ -53,7 +53,7 @@ class IncomeControllerTest : BaseTest() {
 
         assertThat(result).hasSize(1)
         assertThat(result[0].id).isEqualTo(income.id)
-        assertThat(result[0].source.id).isEqualTo(income.source!!.id)
+        assertThat(result[0].source.id).isEqualTo(income.source.id)
         assertThat(result[0].monthlyAmount).isEqualTo(income.monthlyAmount)
     }
 

--- a/backend/src/test/kotlin/org/globe42/web/incomes/IncomeSourceControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/incomes/IncomeSourceControllerMvcTest.kt
@@ -57,9 +57,9 @@ class IncomeSourceControllerMvcTest {
         mvc.perform(get("/api/income-sources"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(42))
-            .andExpect(jsonPath("$[0].name").value(incomeSource.name!!))
-            .andExpect(jsonPath("$[0].type.id").value(incomeSource.type!!.id!!))
-            .andExpect(jsonPath("$[0].type.type").value(incomeSource.type!!.type!!))
+            .andExpect(jsonPath("$[0].name").value(incomeSource.name))
+            .andExpect(jsonPath("$[0].type.id").value(incomeSource.type.id!!))
+            .andExpect(jsonPath("$[0].type.type").value(incomeSource.type.type))
             .andExpect(jsonPath("$[0].maxMonthlyAmount").value(incomeSource.maxMonthlyAmount!!.toDouble()))
     }
 
@@ -78,7 +78,7 @@ class IncomeSourceControllerMvcTest {
     fun `should create`() {
         val command = createIncomeSourceCommand()
         whenever(mockIncomeSourceDao.save(any<IncomeSource>())).thenReturn(incomeSource)
-        whenever(mockIncomeSourceTypeDao.findById(command.typeId)).thenReturn(Optional.of(incomeSource.type!!))
+        whenever(mockIncomeSourceTypeDao.findById(command.typeId)).thenReturn(Optional.of(incomeSource.type))
 
         mvc.perform(
             post("/api/income-sources")
@@ -95,7 +95,7 @@ class IncomeSourceControllerMvcTest {
         val command = createIncomeSourceCommand()
 
         whenever(mockIncomeSourceDao.findById(incomeSource.id!!)).thenReturn(Optional.of(incomeSource))
-        whenever(mockIncomeSourceTypeDao.findById(command.typeId)).thenReturn(Optional.of(incomeSource.type!!))
+        whenever(mockIncomeSourceTypeDao.findById(command.typeId)).thenReturn(Optional.of(incomeSource.type))
 
         mvc.perform(
             put("/api/income-sources/{sourceId}", incomeSource.id)

--- a/backend/src/test/kotlin/org/globe42/web/incomes/IncomeSourceControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/incomes/IncomeSourceControllerTest.kt
@@ -58,8 +58,8 @@ class IncomeSourceControllerTest : BaseTest() {
         val (id, name, type, maxMonthlyAmount) = result[0]
         assertThat(id).isEqualTo(incomeSource.id)
         assertThat(name).isEqualTo(incomeSource.name)
-        assertThat(type.id).isEqualTo(incomeSource.type!!.id)
-        assertThat(type.type).isEqualTo(incomeSource.type!!.type)
+        assertThat(type.id).isEqualTo(incomeSource.type.id)
+        assertThat(type.type).isEqualTo(incomeSource.type.type)
         assertThat(maxMonthlyAmount).isEqualTo(incomeSource.maxMonthlyAmount)
         assertThat(id).isEqualTo(incomeSource.id)
     }
@@ -168,7 +168,7 @@ class IncomeSourceControllerTest : BaseTest() {
 
     private fun assertIncomeSourceEqualsCommand(source: IncomeSource, command: IncomeSourceCommandDTO) {
         assertThat(source.name).isEqualTo(command.name)
-        assertThat(source.type!!.id).isEqualTo(command.typeId)
+        assertThat(source.type.id).isEqualTo(command.typeId)
         assertThat(source.maxMonthlyAmount).isEqualTo(command.maxMonthlyAmount)
     }
 }

--- a/backend/src/test/kotlin/org/globe42/web/persons/PersonNoteControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/persons/PersonNoteControllerTest.kt
@@ -75,7 +75,7 @@ class PersonNoteControllerTest : BaseTest() {
         assertThat(id).isEqualTo(note2.id) // sorted chronologically
         assertThat(creationInstant).isEqualTo(note2.creationInstant)
         assertThat(text).isEqualTo(note2.text) // sorted chronologically
-        assertThat(creator.id).isEqualTo(note2.creator!!.id) // sorted chronologically
+        assertThat(creator.id).isEqualTo(note2.creator.id) // sorted chronologically
 
         assertThat(result[1].creator.id).isEqualTo(creator.id)
     }

--- a/backend/src/test/kotlin/org/globe42/web/security/AuthenticationControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/security/AuthenticationControllerMvcTest.kt
@@ -51,7 +51,7 @@ class AuthenticationControllerMvcTest {
                 .content(objectMapper.writeValueAsBytes(credentials))
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.login").value(user.login!!))
+            .andExpect(jsonPath("$.login").value(user.login))
             .andExpect(jsonPath("$.admin").value(user.admin))
             .andExpect(jsonPath("$.token").value(token))
     }

--- a/backend/src/test/kotlin/org/globe42/web/tasks/TaskControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/tasks/TaskControllerTest.kt
@@ -87,10 +87,10 @@ class TaskControllerTest : BaseTest() {
         assertThat(dto.status).isEqualTo(task1.status)
         assertThat(dto.description).isEqualTo(task1.description)
         assertThat(dto.title).isEqualTo(task1.title)
-        assertThat(dto.category.id).isEqualTo(task1.category!!.id)
-        assertThat(dto.category.name).isEqualTo(task1.category!!.name)
+        assertThat(dto.category.id).isEqualTo(task1.category.id)
+        assertThat(dto.category.name).isEqualTo(task1.category.name)
         assertThat(dto.dueDate).isEqualTo(task1.dueDate)
-        assertThat(dto.creator.id).isEqualTo(task1.creator!!.id)
+        assertThat(dto.creator.id).isEqualTo(task1.creator.id)
         assertThat(dto.assignee!!.id).isEqualTo(task1.assignee!!.id)
         assertThat(dto.concernedPerson!!.id).isEqualTo(task1.concernedPerson!!.id)
     }
@@ -308,7 +308,7 @@ class TaskControllerTest : BaseTest() {
 
         assertThat(task1.title).isEqualTo(command.title)
         assertThat(task1.description).isEqualTo(command.description)
-        assertThat(task1.category!!.id).isEqualTo(command.categoryId)
+        assertThat(task1.category.id).isEqualTo(command.categoryId)
         assertThat(task1.dueDate).isEqualTo(command.dueDate)
         assertThat(task1.concernedPerson!!.id).isEqualTo(person.id!!)
         assertThat(task1.assignee!!.id).isEqualTo(user.id!!)
@@ -388,7 +388,7 @@ internal fun createCommand(concernedPersonId: Long?, assigneeId: Long?): TaskCom
     )
 }
 
-internal fun createSpentTime(id: Long, minutes: Int, creator: User?): SpentTime {
+internal fun createSpentTime(id: Long, minutes: Int, creator: User): SpentTime {
     val spentTime = SpentTime(id)
     spentTime.minutes = minutes
     spentTime.creator = creator

--- a/backend/src/test/kotlin/org/globe42/web/tasks/TaskStatisticsControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/tasks/TaskStatisticsControllerMvcTest.kt
@@ -47,8 +47,8 @@ class TaskStatisticsControllerMvcTest {
                 .param("to", criteria.to.toString())
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.statistics[0].user.login").value(user.login!!))
-            .andExpect(jsonPath("$.statistics[0].category.name").value(meal.name!!))
+            .andExpect(jsonPath("$.statistics[0].user.login").value(user.login))
+            .andExpect(jsonPath("$.statistics[0].category.name").value(meal.name))
             .andExpect(jsonPath("$.statistics[0].minutes").value(100))
     }
 }

--- a/backend/src/test/kotlin/org/globe42/web/users/UserControllerMvcTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/users/UserControllerMvcTest.kt
@@ -53,7 +53,7 @@ class UserControllerMvcTest {
         mvc.perform(get("/api/users/me"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(user.id!!))
-            .andExpect(jsonPath("$.login").value(user.login!!))
+            .andExpect(jsonPath("$.login").value(user.login))
             .andExpect(jsonPath("$.password").doesNotExist())
     }
 
@@ -63,6 +63,7 @@ class UserControllerMvcTest {
         val user = createUser(userId)
         whenever(mockCurrentUser.userId).thenReturn(userId)
         whenever(mockUserDao.findNotDeletedById(userId)).thenReturn(Optional.of(user))
+        whenever(mockPasswordDigester.hash("newPassword")).thenReturn("hashedNewPassword")
 
         val command = ChangePasswordCommandDTO("newPassword")
 
@@ -82,7 +83,7 @@ class UserControllerMvcTest {
         mvc.perform(get("/api/users"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(user.id!!))
-            .andExpect(jsonPath("$[0].login").value(user.login!!))
+            .andExpect(jsonPath("$[0].login").value(user.login))
             .andExpect(jsonPath("$[0].password").doesNotExist())
     }
 
@@ -142,7 +143,7 @@ class UserControllerMvcTest {
 
         mvc.perform(post("/api/users/{userId}/password-resets", user.id))
             .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.login").value(user.login!!))
+            .andExpect(jsonPath("$.login").value(user.login))
             .andExpect(jsonPath("$.generatedPassword").value("password"))
     }
 }

--- a/backend/src/test/kotlin/org/globe42/web/users/UserControllerTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/users/UserControllerTest.kt
@@ -167,7 +167,7 @@ class UserControllerTest : BaseTest() {
     @Test
     fun `should not throw when updating with same login`() {
         val user = createUser(userId)
-        val command = UserCommandDTO(user.login!!, false)
+        val command = UserCommandDTO(user.login, false)
         whenever(mockUserDao.findNotDeletedById(userId)).thenReturn(Optional.of(user))
 
         whenever(mockUserDao.findNotDeletedByLogin(command.login)).thenReturn(Optional.of(user))


### PR DESCRIPTION
This change consists (mainly) in using lateinit non-nullable vars in entities for fields that are not nullable in database.
It fits very well when the entity is read frm the database: hibernate indeed late inits the variables. 
When we create the entity, we are responsible for initializing the variables before reading them (which happens all the time in the current code).
If we really need to test if a variable is initialized or not, we can use http://kotlinlang.org/docs/reference/whatsnew12.html#checking-whether-a-lateinit-var-is-initialized

I would like your opinion on this change.

I personally like it, because we read properties much more often than we create entities, and knowing that they're not null is really helpful. This also avoids useless `!!` of `?.` usages. 

On the other hand, it forces us to be rigorous in tests: and not to read a value that hasn't been initialized (I had to fix only one test to achieve that).