### PR TITLE
refactor: improve the way arrays are sorted, allow multiple sort criteria

### DIFF
--- a/frontend/src/app/participants/participants.component.ts
+++ b/frontend/src/app/participants/participants.component.ts
@@ -19,7 +19,7 @@ export class ParticipantsComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.data.subscribe(data => {
-      this.participants = sortBy(data['participants'], p => displayFullname(p));
+      this.participants = sortBy<ParticipantModel>(data.participants, displayFullname);
     });
     this.route.paramMap.subscribe(paramMap => {
       this.activityType = paramMap.get('activityType') as ActivityType;

--- a/frontend/src/app/person-files/person-files.component.ts
+++ b/frontend/src/app/person-files/person-files.component.ts
@@ -4,7 +4,7 @@ import { FileModel } from '../models/file.model';
 import { PersonFileService } from '../person-file.service';
 import { PersonModel } from '../models/person.model';
 import { ConfirmService } from '../confirm.service';
-import { sortBy } from '../utils';
+import { Comparator, sortBy } from '../utils';
 import { HttpEventType } from '@angular/common/http';
 import { finalize, switchMap } from 'rxjs/operators';
 
@@ -69,7 +69,7 @@ export class PersonFilesComponent implements OnInit {
     this.personFileService.list(this.person.id)
       .subscribe(files => {
         this.loading = false;
-        this.files = sortBy(files, file => file.creationInstant, true);
+        this.files = sortBy(files, Comparator.comparing<FileModel>(file => file.creationInstant).reversed());
       });
   }
 }

--- a/frontend/src/app/spent-time-statistics/spent-time-statistics.component.ts
+++ b/frontend/src/app/spent-time-statistics/spent-time-statistics.component.ts
@@ -68,7 +68,7 @@ export class SpentTimeStatisticsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.users = sortBy(this.route.snapshot.data['users'], user => user.login);
+    this.users = sortBy<UserModel>(this.route.snapshot.data.users, user => user.login);
 
     // If no param, default to the current month
     const paramMap = this.route.snapshot.queryParamMap;

--- a/frontend/src/app/task.service.ts
+++ b/frontend/src/app/task.service.ts
@@ -5,7 +5,7 @@ import { TaskModel } from './models/task.model';
 import { Page } from './models/page';
 import { TaskCommand } from './models/task.command';
 import { SpentTimeModel } from './models/spent-time.model';
-import { sortBy } from './utils';
+import { Comparator, sortBy } from './utils';
 import { TaskCategoryModel } from './models/task-category.model';
 import { CurrentUserService } from './current-user/current-user.service';
 import { SpentTimeStatisticsCriteria } from './models/spent-time-statistics.criteria';
@@ -90,7 +90,7 @@ export class TaskService {
 
   listSpentTimes(taskId: number): Observable<Array<SpentTimeModel>> {
     return this.http.get<Array<SpentTimeModel>>(`/api/tasks/${taskId}/spent-times`).pipe(
-      map(list => sortBy(list, spentTime => spentTime.creationInstant, true))
+      map(list => sortBy(list, Comparator.comparing<SpentTimeModel>(spentTime => spentTime.creationInstant).reversed()))
     );
   }
 

--- a/frontend/src/app/utils.spec.ts
+++ b/frontend/src/app/utils.spec.ts
@@ -1,4 +1,4 @@
-import { dateToIso, interpolate, isoToDate, sortBy } from './utils';
+import { Comparator, dateToIso, interpolate, isoToDate, sortBy } from './utils';
 
 describe('utils', () => {
   it('should sort by', () => {
@@ -24,9 +24,52 @@ describe('utils', () => {
       { foo: 'b' }
     ];
 
-    const result = sortBy(array, o => o.foo, true);
+    const result = sortBy(array, Comparator.comparing<{ foo: string }>(o => o.foo).reversed());
     expect(result.map(o => o.foo)).toEqual(['c', 'b', 'b', 'a', 'a']);
     expect(result).not.toBe(array);
+  });
+
+  it('should compare then compare by a second function', () => {
+    const array = [
+      { foo: 'b', bar: 1 },
+      { foo: 'a', bar: 1 },
+      { foo: 'c', bar: 1 },
+      { foo: 'a', bar: 0 },
+      { foo: 'b', bar: 0 }
+    ];
+
+    const result = sortBy(array, Comparator.comparing<{ foo: string, bar: number }>(o => o.foo).thenComparing(o => o.bar));
+    expect(result).toEqual(
+      [
+        { foo: 'a', bar: 0 },
+        { foo: 'a', bar: 1 },
+        { foo: 'b', bar: 0 },
+        { foo: 'b', bar: 1 },
+        { foo: 'c', bar: 1 }
+      ]
+    );
+  });
+
+  it('should compare then compare by a second comparator', () => {
+    const array = [
+      { foo: 'b', bar: 1 },
+      { foo: 'a', bar: 1 },
+      { foo: 'c', bar: 1 },
+      { foo: 'a', bar: 0 },
+      { foo: 'b', bar: 0 }
+    ];
+
+    const result = sortBy(array, Comparator.comparing<{ foo: string, bar: number }>(o => o.foo)
+      .thenComparing(Comparator.comparing<{ foo: string, bar: number }>(o => o.bar).reversed()));
+    expect(result).toEqual(
+      [
+        { foo: 'a', bar: 1 },
+        { foo: 'a', bar: 0 },
+        { foo: 'b', bar: 1 },
+        { foo: 'b', bar: 0 },
+        { foo: 'c', bar: 1 }
+      ]
+    );
   });
 
   it('should interpolate', () => {


### PR DESCRIPTION
This isn't really needed, but I wanted to experiment, and having `.reversed()` rather than `true` makes the code clearer