### PR TITLE
refactor: improve confirm service

### DIFF
--- a/frontend/src/app/confirm.service.spec.ts
+++ b/frontend/src/app/confirm.service.spec.ts
@@ -74,8 +74,8 @@ describe('ConfirmService and its modal component', () => {
     expect(document.querySelector('.modal-content')).toBeFalsy();
   });
 
-  it('should error when not confirming', (done: DoneFn) => {
-    confirm({message: 'Really?'}).subscribe(null, () => done());
+  it('should error when not confirming and errorOnClose is true', (done: DoneFn) => {
+    confirm({message: 'Really?', errorOnClose: true}).subscribe(null, () => done());
     const noButton = modalContent.querySelectorAll('button')[2];
     expect(noButton.textContent).toBe('Non');
     noButton.click();
@@ -85,8 +85,8 @@ describe('ConfirmService and its modal component', () => {
     expect(document.querySelector('.modal-content')).toBeFalsy();
   });
 
-  it('should error when closing', (done: DoneFn) => {
-    confirm({message: 'Really?'}).subscribe(null, () => done());
+  it('should error when closing and errorOnClose is true', (done: DoneFn) => {
+    confirm({message: 'Really?', errorOnClose: true}).subscribe(null, () => done());
     const closeButton = modalContent.querySelectorAll('button')[0];
     expect(closeButton.textContent).toContain('×');
     closeButton.click();
@@ -95,4 +95,16 @@ describe('ConfirmService and its modal component', () => {
 
     expect(document.querySelector('.modal-content')).toBeFalsy();
   });
+
+  it('should do nothing when not confirming and errorOnClose is not set', (done: DoneFn) => {
+    confirm({message: 'Really?'}).subscribe(null, () => fail(), () => done());
+    const noButton = modalContent.querySelectorAll('button')[2];
+    expect(noButton.textContent).toBe('Non');
+    noButton.click();
+
+    fixture.detectChanges();
+
+    expect(document.querySelector('.modal-content')).toBeFalsy();
+  });
+
 });

--- a/frontend/src/app/confirm.service.ts
+++ b/frontend/src/app/confirm.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ConfirmModalContentComponent } from './confirm-modal-content/confirm-modal-content.component';
-import { Observable, from } from 'rxjs';
+import { Observable, from, EMPTY, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 export interface ConfirmOptions {
   message: string;
   title?: string;
+  errorOnClose?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -17,6 +19,8 @@ export class ConfirmService {
     const modalRef = this.modalService.open(ConfirmModalContentComponent);
     modalRef.componentInstance.title = options.title || 'Confirmation';
     modalRef.componentInstance.message = options.message;
-    return from(modalRef.result);
+    return from(modalRef.result).pipe(
+      catchError(err => options.errorOnClose ? throwError(err || 'not confirmed') : EMPTY)
+    );
   }
 }

--- a/frontend/src/app/person-family/person-family.component.spec.ts
+++ b/frontend/src/app/person-family/person-family.component.spec.ts
@@ -10,7 +10,7 @@ import { ConfirmService } from '../confirm.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
 import { FamilyModel } from '../models/family.model';
 import { By } from '@angular/platform-browser';
-import { of, throwError } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
 import { FullnamePipe } from '../fullname.pipe';
 
@@ -168,7 +168,7 @@ describe('PersonFamilyComponent', () => {
     const confirmService: ConfirmService = TestBed.get(ConfirmService);
     const familyService: FamilyService = TestBed.get(FamilyService);
 
-    spyOn(confirmService, 'confirm').and.returnValue(throwError(undefined));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(familyService, 'delete').and.returnValue(of(undefined));
 
     fixture.nativeElement.querySelector('#delete').click();

--- a/frontend/src/app/person-family/person-family.component.ts
+++ b/frontend/src/app/person-family/person-family.component.ts
@@ -55,6 +55,6 @@ export class PersonFamilyComponent implements OnInit {
       this.family = null;
       this.france = null;
       this.abroad = null;
-    }, () => {});
+    });
   }
 }

--- a/frontend/src/app/person-network-members/person-network-members.component.spec.ts
+++ b/frontend/src/app/person-network-members/person-network-members.component.spec.ts
@@ -9,7 +9,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { DisplayNetworkMemberTypePipe } from '../display-network-member-type.pipe';
 import { ConfirmService } from '../confirm.service';
 import { NetworkMemberService } from '../network-member.service';
-import { of, throwError } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
 import { ValdemortModule } from 'ngx-valdemort';
 import { PageTitleDirective } from '../page-title.directive';
@@ -118,7 +118,7 @@ describe('PersonNetworkMembersComponent', () => {
     const confirmService: ConfirmService = TestBed.get(ConfirmService);
     const networkMemberService: NetworkMemberService = TestBed.get(NetworkMemberService);
 
-    spyOn(confirmService, 'confirm').and.returnValue(throwError(undefined));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(networkMemberService, 'delete');
     spyOn(networkMemberService, 'list');
 

--- a/frontend/src/app/person-network-members/person-network-members.component.ts
+++ b/frontend/src/app/person-network-members/person-network-members.component.ts
@@ -40,7 +40,7 @@ export class PersonNetworkMembersComponent implements OnInit {
     }).pipe(
       switchMap(() => this.networkMemberService.delete(this.person.id, member.id)),
       switchMap(() => this.networkMemberService.list(this.person.id)),
-    ).subscribe(members => this.members = members, () => {});
+    ).subscribe(members => this.members = members);
   }
 
   showMemberEdition(member: NetworkMemberModel | null) {

--- a/frontend/src/app/person-note-edition.guard.spec.ts
+++ b/frontend/src/app/person-note-edition.guard.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { PersonNoteEditionGuard } from './person-note-edition.guard';
 import { PersonComponent } from './person/person.component';
-import { ConfirmService } from './confirm.service';
+import { ConfirmOptions, ConfirmService } from './confirm.service';
 import { Observable, of, throwError } from 'rxjs';
 
 describe('PersonNoteEditionGuard', () => {
@@ -50,6 +50,8 @@ describe('PersonNoteEditionGuard', () => {
     (guard.canDeactivate(component) as Observable<boolean>).subscribe(r => result = r);
 
     expect(result).toBe(false);
-    expect(confirmService.confirm).toHaveBeenCalled();
+    expect(confirmService.confirm).toHaveBeenCalledWith({
+      asymmetricMatch: (actual: ConfirmOptions) => actual.errorOnClose
+    });
   });
 });

--- a/frontend/src/app/person-note-edition.guard.ts
+++ b/frontend/src/app/person-note-edition.guard.ts
@@ -16,7 +16,8 @@ export class PersonNoteEditionGuard implements CanDeactivate<PersonComponent> {
     }
 
     return this.confirmService.confirm({
-      message: `Vous avez une note en cours d'édition. Voulez-vous vraiment quitter la page\u00a0?`
+      message: `Vous avez une note en cours d'édition. Voulez-vous vraiment quitter la page\u00a0?`,
+      errorOnClose: true
     }).pipe(
       map(() => true),
       catchError(() => of(false))

--- a/frontend/src/app/person-notes/person-notes.component.spec.ts
+++ b/frontend/src/app/person-notes/person-notes.component.spec.ts
@@ -8,7 +8,7 @@ import { PersonNoteService } from '../person-note.service';
 import { PersonModel } from '../models/person.model';
 import { NoteModel } from '../models/note.model';
 import { ConfirmService } from '../confirm.service';
-import { of, Subject, throwError } from 'rxjs';
+import { EMPTY, of, Subject } from 'rxjs';
 import { UserModel } from '../models/user.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
@@ -181,13 +181,13 @@ describe('PersonNotesComponent', () => {
     expect(tester.notes.length).toBe(1);
   });
 
-  it('should not delete note after confirmation', () => {
+  it('should not delete note if not confirmed', () => {
     // create component with 2 notes
     const personNoteService = TestBed.get(PersonNoteService);
     const confirmService = TestBed.get(ConfirmService);
     spyOn(personNoteService, 'list').and.returnValue(of(notes));
     spyOn(personNoteService, 'delete').and.returnValue(of(null));
-    spyOn(confirmService, 'confirm').and.returnValue(throwError('nok'));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
 
     tester.componentInstance.person = person;
     tester.detectChanges();

--- a/frontend/src/app/person-notes/person-notes.component.ts
+++ b/frontend/src/app/person-notes/person-notes.component.ts
@@ -79,11 +79,12 @@ export class PersonNotesComponent implements OnInit {
 
   deleteNote(note: NoteModel) {
     this.confirmService.confirm({
-      message: 'Voulez-vous vraiment supprimer définitivement cette note\u00a0?'
+      message: 'Voulez-vous vraiment supprimer définitivement cette note\u00a0?',
+      errorOnClose: true
     }).subscribe(() => {
       const action = this.personNoteService.delete(this.person.id, note.id);
       this.reloadAfterAction(action);
-    }, () => {});
+    });
   }
 
   private reloadAfterAction(action: Observable<any>) {

--- a/frontend/src/app/person-resources/person-resources.component.spec.ts
+++ b/frontend/src/app/person-resources/person-resources.component.spec.ts
@@ -11,7 +11,7 @@ import { LOCALE_ID } from '@angular/core';
 import { ChargeModel } from '../models/charge.model';
 import { ChargeService } from '../charge.service';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
-import { of, throwError } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { PerUnitRevenueInformationModel } from '../models/per-unit-revenue-information.model';
 import { PerUnitRevenueInformationService } from '../per-unit-revenue-information.service';
 import { ComponentTester, fakeRoute, fakeSnapshot, TestButton } from 'ngx-speculoos';
@@ -176,7 +176,7 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const incomeService = TestBed.get(IncomeService);
-    spyOn(confirmService, 'confirm').and.returnValue(throwError(null));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(incomeService, 'delete');
 
     tester.deleteIncomeButtons[0].click();
@@ -242,7 +242,7 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const chargeService = TestBed.get(ChargeService);
-    spyOn(confirmService, 'confirm').and.returnValue(throwError(null));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(chargeService, 'delete');
 
     tester.deleteChargeButtons[0].click();
@@ -323,7 +323,7 @@ describe('PersonResourcesComponent', () => {
 
     const confirmService = TestBed.get(ConfirmService);
     const infoService = TestBed.get(PerUnitRevenueInformationService);
-    spyOn(confirmService, 'confirm').and.returnValue(throwError(null));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(infoService, 'delete');
 
     tester.deletePerUnitRevenueInformationButton.click();

--- a/frontend/src/app/person-resources/person-resources.component.ts
+++ b/frontend/src/app/person-resources/person-resources.component.ts
@@ -37,14 +37,14 @@ export class PersonResourcesComponent {
     this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer le revenu ${income.source.name}\u00A0?`}).pipe(
       switchMap(() => this.incomeService.delete(this.person.id, income.id)),
       switchMap(() => this.incomeService.list(this.person.id))
-    ).subscribe(incomes => this.incomes = incomes, () => {});
+    ).subscribe(incomes => this.incomes = incomes);
   }
 
   deleteCharge(charge: ChargeModel) {
     this.confirmService.confirm({ message: `Voulez-vous vraiment supprimer la charge ${charge.type.name}\u00A0?`}).pipe(
       switchMap(() => this.chargeService.delete(this.person.id, charge.id)),
       switchMap(() => this.chargeService.list(this.person.id))
-    ).subscribe(charges => this.charges = charges, () => {});
+    ).subscribe(charges => this.charges = charges);
   }
 
   totalMonthlyIncomeAmount() {
@@ -85,6 +85,6 @@ export class PersonResourcesComponent {
       message: 'Voulez-vous vraiment supprimer les informations utilisées pour le calcul du revenu par unité de consommation\u00A0?'
     }).pipe(
       switchMap(() => this.perUnitRevenueInformationService.delete(this.person.id))
-    ).subscribe(() => this.perUnitRevenueInformation = null, () => {});
+    ).subscribe(() => this.perUnitRevenueInformation = null);
   }
 }

--- a/frontend/src/app/person-wedding-events/person-wedding-events.component.spec.ts
+++ b/frontend/src/app/person-wedding-events/person-wedding-events.component.spec.ts
@@ -9,7 +9,7 @@ import { WeddingEventService } from '../wedding-event.service';
 import { DisplayWeddingEventTypePipe, WEDDING_EVENT_TYPE_TRANSLATIONS } from '../display-wedding-event-type.pipe';
 import { ActivatedRoute } from '@angular/router';
 import { ConfirmService } from '../confirm.service';
-import { of, throwError } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { DateTime } from 'luxon';
 import { LOCALE_ID } from '@angular/core';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
@@ -18,8 +18,8 @@ import { DisplayLocationPipe, LOCATION_TRANSLATIONS } from '../display-location.
 import { ComponentTester, speculoosMatchers, TestButton } from 'ngx-speculoos';
 import { Location } from '../models/family.model';
 import { PageTitleDirective } from '../page-title.directive';
-import Spy = jasmine.Spy;
 import { FullnamePipe } from '../fullname.pipe';
+import Spy = jasmine.Spy;
 
 class PersonWeddingEventsComponentTester extends ComponentTester<PersonWeddingEventsComponent> {
   constructor() {
@@ -164,7 +164,7 @@ describe('PersonWeddingEventsComponent', () => {
       const confirmService = TestBed.get(ConfirmService);
       const weddingEventService = TestBed.get(WeddingEventService);
 
-      (confirmService.confirm as Spy).and.returnValue(throwError(null));
+      (confirmService.confirm as Spy).and.returnValue(EMPTY);
 
       component.deleteEvent(events[1]);
       expect(component.events).toEqual(events);

--- a/frontend/src/app/person-wedding-events/person-wedding-events.component.ts
+++ b/frontend/src/app/person-wedding-events/person-wedding-events.component.ts
@@ -40,7 +40,7 @@ export class PersonWeddingEventsComponent {
     }).pipe(
       switchMap(() => this.weddingEventService.delete(this.person.id, event.id)),
       switchMap(() => this.weddingEventService.list(this.person.id))
-    ).subscribe(events => this.events = events, () => {});
+    ).subscribe(events => this.events = events);
   }
 
   showEventCreation() {

--- a/frontend/src/app/person/person.component.spec.ts
+++ b/frontend/src/app/person/person.component.spec.ts
@@ -19,7 +19,7 @@ import { ConfirmService } from '../confirm.service';
 import { PersonService } from '../person.service';
 import { FullnamePipe } from '../fullname.pipe';
 import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
-import { of, throwError } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
 
 describe('PersonComponent', () => {
@@ -233,7 +233,7 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(throwError('nok'));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(personService, 'delete').and.returnValue(of(null));
     spyOn(router, 'navigate');
 
@@ -276,7 +276,7 @@ describe('PersonComponent', () => {
     const personService = TestBed.get(PersonService);
     const router = TestBed.get(Router);
 
-    spyOn(confirmService, 'confirm').and.returnValue(throwError('nok'));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
     spyOn(personService, 'resurrect').and.returnValue(of(null));
     spyOn(router, 'navigate');
 

--- a/frontend/src/app/person/person.component.ts
+++ b/frontend/src/app/person/person.component.ts
@@ -37,14 +37,14 @@ export class PersonComponent implements OnInit {
     this.confirmService.confirm(
       { message: `Voulez-vous vraiment supprimer ${displayFullname(this.person)}\u00a0?`}).pipe(
       switchMap(() => this.personService.delete(this.person.id))
-    ).subscribe(() => this.router.navigate(['/persons']), () => {});
+    ).subscribe(() => this.router.navigate(['/persons']));
   }
 
   resurrect() {
     this.confirmService.confirm(
       { message: `Voulez-vous vraiment annuler la suppression de ${displayFullname(this.person)}\u00a0?`}).pipe(
       switchMap(() => this.personService.resurrect(this.person.id))
-    ).subscribe(() => this.router.navigate(['/persons']), () => {});
+    ).subscribe(() => this.router.navigate(['/persons']));
   }
 
   private createMapsUrl() {

--- a/frontend/src/app/users/users.component.spec.ts
+++ b/frontend/src/app/users/users.component.spec.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute } from '@angular/router';
 import { UserModel } from '../models/user.model';
 import { UserService } from '../user.service';
 import { ConfirmService } from '../confirm.service';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { BehaviorSubject, EMPTY, of } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { CurrentUserModule } from '../current-user/current-user.module';
@@ -68,7 +68,7 @@ describe('UsersComponent', () => {
     const confirmService = TestBed.get(ConfirmService);
 
     spyOn(userService, 'delete');
-    spyOn(confirmService, 'confirm').and.returnValue(throwError('nope'));
+    spyOn(confirmService, 'confirm').and.returnValue(EMPTY);
 
     const fixture = TestBed.createComponent(UsersComponent);
     fixture.detectChanges();

--- a/frontend/src/app/users/users.component.ts
+++ b/frontend/src/app/users/users.component.ts
@@ -29,7 +29,7 @@ export class UsersComponent implements OnInit {
     this.confirmService.confirm({message: `Voulez-vous vraiment supprimer l\'utilisateur ${user.login}\u00A0?`}).pipe(
       switchMap(() => this.userService.delete(user.id)),
       switchMap(() => this.userService.list())
-    ).subscribe(users => this.users = sortBy(users, u => u.login), () => {});
+    ).subscribe(users => this.users = sortBy(users, u => u.login));
   }
 
   isCurrentUser(user: UserModel) {


### PR DESCRIPTION
Instead of emitting an error on close, which forces every caller to use an error callback in order to avoid an error in tests and in the browser console, the observable simply completes without emitting any event.
This makes the nominal case simpler.
If the caller wants to be notified when closed (like in a CanDeactivate guard), then the caller can pass `errorOnClose: true` in the confirm options.