### PR TITLE
feat: add a thin github-like navigation progress bar at the top

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,4 +1,7 @@
-<gl-menu></gl-menu>
+<div class="fixed-top">
+  <gl-navigation-progress></gl-navigation-progress>
+  <gl-menu></gl-menu>
+</div>
 <div class="container" style="margin-top: 70px;">
   <gl-error></gl-error>
   <router-outlet></router-outlet>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -83,6 +83,7 @@ import { ValidationDefaultsComponent } from './validation-defaults/validation-de
 import { ValdemortModule } from 'ngx-valdemort';
 import { DisplayLocationPipe } from './display-location.pipe';
 import { PageTitleDirective } from './page-title.directive';
+import { NavigationProgressComponent } from './navigation-progress/navigation-progress.component';
 
 registerLocaleData(localeFr);
 
@@ -158,7 +159,8 @@ registerLocaleData(localeFr);
     DisplayLocationPipe,
     DisplayVisaPipe,
     DisplayResidencePermitPipe,
-    PageTitleDirective
+    PageTitleDirective,
+    NavigationProgressComponent
   ],
   entryComponents: [
     ConfirmModalContentComponent

--- a/frontend/src/app/menu/menu.component.html
+++ b/frontend/src/app/menu/menu.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-light navbar-expand-md bg-light fixed-top">
+<nav class="navbar navbar-light navbar-expand-md bg-light">
   <a class="navbar-brand" routerLink="/">
     <span class="fa fa-globe"></span>
     Globe42

--- a/frontend/src/app/navigation-progress/navigation-progress.component.html
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.html
@@ -1,3 +1,3 @@
 <div class="navigation-progress-wrapper">
-  <ngb-progressbar *ngIf="value$ | async as value" [value]="value - 1" class="bg-light"></ngb-progressbar>
+  <ngb-progressbar *ngIf="progress$ | async as progress" [value]="progress.value" class="bg-light"></ngb-progressbar>
 </div>

--- a/frontend/src/app/navigation-progress/navigation-progress.component.html
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.html
@@ -1,0 +1,3 @@
+<div class="navigation-progress-wrapper">
+  <ngb-progressbar *ngIf="value$ | async as value" [value]="value - 1" class="bg-light"></ngb-progressbar>
+</div>

--- a/frontend/src/app/navigation-progress/navigation-progress.component.scss
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.scss
@@ -1,0 +1,17 @@
+@import '../../common';
+
+.navigation-progress-wrapper {
+  background-color: $light;
+  height: .1rem;
+
+  .progress {
+    background-color: $light;
+    @include border-radius(0);
+  }
+
+  .progress-bar {
+    @include transition(width .5s ease);
+  }
+}
+
+

--- a/frontend/src/app/navigation-progress/navigation-progress.component.spec.ts
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.spec.ts
@@ -1,0 +1,94 @@
+import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
+
+import { NavigationProgressComponent } from './navigation-progress.component';
+import { ComponentTester } from 'ngx-speculoos';
+import { By } from '@angular/platform-browser';
+import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap';
+import { NavigationCancel, NavigationEnd, NavigationStart, Router, RouterEvent } from '@angular/router';
+import { Subject } from 'rxjs';
+import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+
+class NavigationProgressComponentTester extends ComponentTester<NavigationProgressComponent> {
+  constructor() {
+    super(NavigationProgressComponent);
+  }
+
+  get progressBar(): NgbProgressbar | null {
+
+    const debugElement = this.debugElement.query(By.directive(NgbProgressbar));
+    return debugElement && debugElement.componentInstance;
+  }
+
+  get progressValue() {
+    const p = this.progressBar;
+    return p && p.value;
+  }
+
+  adance(millis: number) {
+    tick(millis);
+    this.detectChanges();
+  }
+}
+
+describe('NavigationProgressComponent', () => {
+  let tester: NavigationProgressComponentTester;
+  let events$: Subject<RouterEvent>;
+
+  beforeEach(async(() => {
+    events$ = new Subject<RouterEvent>();
+
+    const fakeRouter = {
+      events: events$.asObservable()
+    } as Router;
+
+    TestBed.configureTestingModule({
+      declarations: [ NavigationProgressComponent ],
+      imports: [ GlobeNgbModule.forRoot() ],
+      providers: [
+        { provide: Router, useValue: fakeRouter }
+      ]
+    });
+
+    tester = new NavigationProgressComponentTester();
+    tester.detectChanges();
+  }));
+
+  it('should not display any progress bar initially', () => {
+    expect(tester.progressBar).toBeNull();
+  });
+
+  it('should display a progress bar at value 0 when navigation starts, and remove it if it ends before 500ms', fakeAsync(() => {
+    events$.next(new NavigationStart(0, 'foo'));
+    tester.adance(1);
+
+    expect(tester.progressBar).not.toBeNull();
+    expect(tester.progressValue).toBe(0);
+    tester.adance(490);
+
+    expect(tester.progressValue).toBe(0);
+    events$.next(new NavigationEnd(0, 'foo', null));
+    tester.adance(100);
+
+    expect(tester.progressBar).toBeNull();
+  }));
+
+  it('should display a progress bar with increasing values, and remove it navigation ends', fakeAsync(() => {
+    events$.next(new NavigationStart(0, 'foo'));
+    tester.adance(1);
+
+    expect(tester.progressValue).toBe(0);
+    tester.adance(500);
+    expect(tester.progressValue).toBe(50);
+    tester.adance(500);
+    expect(tester.progressValue).toBe(75);
+    tester.adance(500);
+    expect(tester.progressValue).toBe(87.5);
+    tester.adance(500);
+    expect(tester.progressValue).toBe(93.75);
+    tester.adance(500);
+    expect(tester.progressValue).toBe(96.875);
+    events$.next(new NavigationCancel(0, 'foo', null));
+    tester.detectChanges();
+    expect(tester.progressBar).toBeNull();
+  }));
+});

--- a/frontend/src/app/navigation-progress/navigation-progress.component.ts
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router } from '@angular/router';
+import { merge, Observable, timer } from 'rxjs';
+import { filter, first, map, switchMap, takeUntil, takeWhile } from 'rxjs/operators';
+
+@Component({
+  selector: 'gl-navigation-progress',
+  templateUrl: './navigation-progress.component.html',
+  styleUrls: ['./navigation-progress.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NavigationProgressComponent implements OnInit {
+
+  value$: Observable<number>;
+
+  constructor(private router: Router) { }
+
+  ngOnInit() {
+    const end$ = this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd || e instanceof NavigationCancel || e instanceof NavigationError)
+    );
+
+    this.value$ = this.router.events.pipe(
+      filter(e => e instanceof NavigationStart), // trigger the emission when a navigation starts
+      switchMap(() => merge( // then emit every 500ms, and when the navigation ends or cancels or errors. This delay must
+                             // match the transition duration in the .scss file
+        timer(0, 500).pipe(
+          map(i => 100 - (100 / Math.pow(2, i))), // emit 0 then 50, 75, 87.5, etc.
+          takeWhile(i => i < 99.95), // stop because that just triggers change detection with no visual change anymore
+          takeUntil(end$) // but stop emitting every 500ms when the navigation ends or cancels or errors
+        ),
+        end$.pipe(first(), map(() => -1)) // set back to -1 when the navigation ends or cancels or errors
+                                          // because the value is shifted (see below)
+      )),
+      map(i => i + 1)  // shift 1 rather than 0 and be able to use *ngIf="value$ | async as value". This sucks.
+    );
+  }
+}

--- a/frontend/src/app/navigation-progress/navigation-progress.component.ts
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.ts
@@ -3,6 +3,10 @@ import { NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Rout
 import { merge, Observable, timer } from 'rxjs';
 import { filter, first, map, switchMap, takeUntil, takeWhile } from 'rxjs/operators';
 
+export interface Progress {
+  value: number;
+}
+
 @Component({
   selector: 'gl-navigation-progress',
   templateUrl: './navigation-progress.component.html',
@@ -11,7 +15,7 @@ import { filter, first, map, switchMap, takeUntil, takeWhile } from 'rxjs/operat
 })
 export class NavigationProgressComponent implements OnInit {
 
-  value$: Observable<number>;
+  progress$: Observable<Progress | null>;
 
   constructor(private router: Router) { }
 
@@ -20,19 +24,19 @@ export class NavigationProgressComponent implements OnInit {
       filter(e => e instanceof NavigationEnd || e instanceof NavigationCancel || e instanceof NavigationError)
     );
 
-    this.value$ = this.router.events.pipe(
+    this.progress$ = this.router.events.pipe(
       filter(e => e instanceof NavigationStart), // trigger the emission when a navigation starts
       switchMap(() => merge( // then emit every 500ms, and when the navigation ends or cancels or errors. This delay must
                              // match the transition duration in the .scss file
         timer(0, 500).pipe(
           map(i => 100 - (100 / Math.pow(2, i))), // emit 0 then 50, 75, 87.5, etc.
           takeWhile(i => i < 99.95), // stop because that just triggers change detection with no visual change anymore
-          takeUntil(end$) // but stop emitting every 500ms when the navigation ends or cancels or errors
+          takeUntil(end$), // but stop emitting every 500ms when the navigation ends or cancels or errors
+          map(i => ({ value: i }))
         ),
-        end$.pipe(first(), map(() => -1)) // set back to -1 when the navigation ends or cancels or errors
-                                          // because the value is shifted (see below)
-      )),
-      map(i => i + 1)  // shift 1 rather than 0 and be able to use *ngIf="value$ | async as value". This sucks.
+        end$.pipe(first(), map(() => null)) // set back to null when the navigation ends or cancels or errors to hide
+                                            // the progress bar
+      ))
     );
   }
 }


### PR DESCRIPTION
To test what it looks like, load the app then set the network speed to slow 3G in the network panel of the chrome dev tools.

@cexbrayat I'd like your advice on 3 things here:

1. This is really cool (IMHO), but only works because each and every page uses a resolver to load its data. Do you have any idea how we could achieve the same thing without resolvers?
2. I don't like the hack of shifting the values by 1 just to be able to use `*ngIf="value$ as async"`. I would prefer using something like  `*ngIf="(value$ as async) !== null"` but that doesn't seem possible.
3. During the navigation, this forces a global change detection every 500ms, although I know that the only thing that should change is the naigtaion progress component itself. Is there anything we can do to limit the scope of the change detection to the component itself? I find that this should be an optimization that Angular could provide, and that would be very helpful for a lot of components that update themselves, but have no impact on the other ones.