### PR TITLE
refactor: improve tests

### DIFF
--- a/backend/src/test/java/org/globe42/test/GlobeMvcTest.java
+++ b/backend/src/test/java/org/globe42/test/GlobeMvcTest.java
@@ -6,12 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.globe42.web.security.AuthenticationConfig;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.core.annotation.AliasFor;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Meta-annotation used to simplify the creation of MVC tests. Indeed, the AuthenticationConfig must be excluded
@@ -23,7 +21,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(
     excludeFilters = @ComponentScan.Filter(
         type = FilterType.ASSIGNABLE_TYPE,

--- a/backend/src/test/kotlin/org/globe42/CrypticApplicationTest.kt
+++ b/backend/src/test/kotlin/org/globe42/CrypticApplicationTest.kt
@@ -1,12 +1,9 @@
 package org.globe42
 
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest
 @TestPropertySource("/test.properties")
 class CrypticApplicationTest {

--- a/backend/src/test/kotlin/org/globe42/dao/BaseDaoTest.kt
+++ b/backend/src/test/kotlin/org/globe42/dao/BaseDaoTest.kt
@@ -4,20 +4,17 @@ import com.ninja_squad.dbsetup.DbSetupTracker
 import com.ninja_squad.dbsetup_kotlin.DbSetupBuilder
 import com.ninja_squad.dbsetup_kotlin.dbSetup
 import com.ninja_squad.dbsetup_kotlin.launchWith
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.annotation.Rollback
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import javax.sql.DataSource
 
 /**
  * Base class for DAO tests
  * @author JB Nizet
  */
-@ExtendWith(SpringExtension::class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestPropertySource("/test.properties")

--- a/backend/src/test/kotlin/org/globe42/web/security/AdminOnlyIntegrationTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/security/AdminOnlyIntegrationTest.kt
@@ -1,17 +1,17 @@
 package org.globe42.web.security
 
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.globe42.dao.UserDao
 import org.globe42.web.exception.ForbiddenException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 
 /**
  * Integration test to verify that calling a method annotated with [AdminOnly] while not being an admin
@@ -19,17 +19,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
  * @author JB Nizet
  */
 @SpringBootTest
-@ExtendWith(SpringExtension::class)
-@TestPropertySource("/test.properties")
 class AdminOnlyIntegrationTest {
 
-    @MockBean
+    @Autowired
     private lateinit var mockCurrentUser: CurrentUser
 
-    @MockBean
+    @Autowired
     private lateinit var mockUserDao: UserDao
 
-    @SpyBean
+    @Autowired
     private lateinit var adminOnlyTester: AdminOnlyTester
 
     @BeforeEach
@@ -55,5 +53,21 @@ class AdminOnlyIntegrationTest {
         }
 
         open fun bar() {}
+    }
+
+    @Configuration
+    @EnableAspectJAutoProxy
+    class AlternateConfiguration {
+        @Bean
+        fun adminOnlyTester() = AdminOnlyTester()
+
+        @Bean
+        fun currentUser() = mock<CurrentUser>()
+
+        @Bean
+        fun userDao() = mock<UserDao>()
+
+        @Bean
+        fun adminOnlyAspect() = AdminOnlyAspect(currentUser(), userDao())
     }
 }

--- a/backend/src/test/kotlin/org/globe42/web/security/AuthenticationTest.kt
+++ b/backend/src/test/kotlin/org/globe42/web/security/AuthenticationTest.kt
@@ -6,11 +6,9 @@ import org.globe42.dao.PersonDao
 import org.globe42.dao.UserDao
 import org.globe42.web.persons.PersonController
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -19,7 +17,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
  * Test for the integration of the authentication filter in the application
  * @author JB Nizet
  */
-@ExtendWith(SpringExtension::class)
 @WebMvcTest(PersonController::class, AuthenticationConfig::class)
 class AuthenticationTest {
     @MockBean


### PR DESCRIPTION
- avoid using unnecessary ExtendWith annotation (since XxxTest is already annotated with it)
- make AdminOnlyIntegrationTest faster by only loading a tiny context instead of the whole context