### PR TITLE
feat: use animations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser": "10.2.2",
     "@angular/platform-browser-dynamic": "10.2.2",
     "@angular/router": "10.2.2",
-    "@ng-bootstrap/ng-bootstrap": "7.0.0",
+    "@ng-bootstrap/ng-bootstrap": "8.0.0",
     "bootstrap": "4.5.3",
     "chart.js": "2.9.4",
     "font-awesome": "4.7.0",

--- a/frontend/src/app/charge-type-edit/charge-type-edit.component.spec.ts
+++ b/frontend/src/app/charge-type-edit/charge-type-edit.component.spec.ts
@@ -11,7 +11,7 @@ import { NgModule } from '@angular/core';
 import { ChargeTypeModel } from '../models/charge-type.model';
 import { of } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ComponentTester, speculoosMatchers } from 'ngx-speculoos';
+import { ComponentTester } from 'ngx-speculoos';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
 import { ValdemortModule } from 'ngx-valdemort';
 import { PageTitleDirective } from '../page-title.directive';
@@ -60,8 +60,6 @@ describe('ChargeTypeEditComponent', () => {
     providers: [ChargeTypeService, ErrorService]
   })
   class TestModule {}
-
-  beforeEach(() => jasmine.addMatchers(speculoosMatchers));
 
   describe('in creation mode', () => {
     const activatedRoute = {

--- a/frontend/src/app/cities-upload/cities-upload.component.spec.ts
+++ b/frontend/src/app/cities-upload/cities-upload.component.spec.ts
@@ -4,7 +4,7 @@ import { CitiesUploadComponent } from './cities-upload.component';
 import { SearchCityService } from '../search-city.service';
 import { Subject } from 'rxjs';
 import { HttpClientModule, HttpEventType, HttpResponse } from '@angular/common/http';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { PageTitleDirective } from '../page-title.directive';
 import { ComponentTester } from 'ngx-speculoos';
 
@@ -35,7 +35,7 @@ describe('CitiesUploadComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [GlobeNgbModule.forRoot(), HttpClientModule],
+      imports: [GlobeNgbTestingModule, HttpClientModule],
       declarations: [CitiesUploadComponent, PageTitleDirective]
     });
 

--- a/frontend/src/app/confirm.service.spec.ts
+++ b/frontend/src/app/confirm.service.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ConfirmModalContentComponent } from './confirm-modal-content/confirm-modal-content.component';
-import { GlobeNgbModule } from './globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from './globe-ngb/globe-ngb-testing.module';
 import { ComponentTester } from 'ngx-speculoos';
 
 @Component({
@@ -56,7 +56,7 @@ describe('ConfirmService and its modal component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, GlobeNgbModule.forRoot()],
+      imports: [RouterTestingModule, GlobeNgbTestingModule],
       declarations: [ConfirmModalContentComponent, TestComponent]
     });
 

--- a/frontend/src/app/error/error.component.html
+++ b/frontend/src/app/error/error.component.html
@@ -1,4 +1,4 @@
-<ngb-alert class="error-alert" type="danger" *ngIf="error" (close)="error = null">
+<ngb-alert class="error-alert" type="danger" *ngIf="error" (closed)="error = null">
   <ng-container *ngIf="error.technical">
     Une erreur technique inattendue s'est produite. Essayez de recharger la page.
     <br />

--- a/frontend/src/app/error/error.component.spec.ts
+++ b/frontend/src/app/error/error.component.spec.ts
@@ -4,7 +4,7 @@ import { ErrorComponent } from './error.component';
 import { ErrorService } from '../error.service';
 import { NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { Subject } from 'rxjs';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ComponentTester } from 'ngx-speculoos';
 
 class ErrorComponentTester extends ComponentTester<ErrorComponent> {
@@ -32,7 +32,7 @@ describe('ErrorComponent', () => {
     fakeRouter = { events: new Subject<any>() };
 
     TestBed.configureTestingModule({
-      imports: [GlobeNgbModule.forRoot()],
+      imports: [GlobeNgbTestingModule],
       declarations: [ErrorComponent],
       providers: [{ provide: Router, useValue: fakeRouter }]
     });

--- a/frontend/src/app/globe-ngb/datepicker-container.component.html
+++ b/frontend/src/app/globe-ngb/datepicker-container.component.html
@@ -1,4 +1,6 @@
 <div class="input-group-prepend" (click)="toggle()">
-  <span class="input-group-text fa fa-calendar" aria-hidden="true"></span>
+  <button type="button" class="btn btn-outline-secondary">
+    <span class="fa fa-calendar" aria-hidden="true"></span>
+  </button>
 </div>
 <ng-content></ng-content>

--- a/frontend/src/app/globe-ngb/datepicker-container.component.spec.ts
+++ b/frontend/src/app/globe-ngb/datepicker-container.component.spec.ts
@@ -1,10 +1,10 @@
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import { GlobeNgbModule } from './globe-ngb.module';
 import { By } from '@angular/platform-browser';
 import { NgbDatepicker, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap';
 import { ComponentTester } from 'ngx-speculoos';
+import { GlobeNgbTestingModule } from './globe-ngb-testing.module';
 
 @Component({
   template: `
@@ -44,7 +44,7 @@ describe('DatepickerContainerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [GlobeNgbModule.forRoot(), ReactiveFormsModule],
+      imports: [GlobeNgbTestingModule, ReactiveFormsModule],
       declarations: [TestComponent]
     });
 

--- a/frontend/src/app/globe-ngb/globe-ngb-testing.module.ts
+++ b/frontend/src/app/globe-ngb/globe-ngb-testing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { NgbConfig } from '@ng-bootstrap/ng-bootstrap';
+import { GlobeNgbModule } from './globe-ngb.module';
+
+/**
+ * A module for unit tests, which imports the root GlobeNgbModule and disables
+ * animations
+ */
+@NgModule({
+  imports: [GlobeNgbModule.forRoot()],
+  exports: [GlobeNgbModule]
+})
+export class GlobeNgbTestingModule {
+  constructor(ngbConfig: NgbConfig) {
+    ngbConfig.animation = false;
+  }
+}

--- a/frontend/src/app/globe-ngb/globe-ngb.module.ts
+++ b/frontend/src/app/globe-ngb/globe-ngb.module.ts
@@ -2,6 +2,7 @@ import { Injectable, ModuleWithProviders, NgModule } from '@angular/core';
 import {
   NgbAlertModule,
   NgbButtonsModule,
+  NgbCollapseModule,
   NgbDateAdapter,
   NgbDateParserFormatter,
   NgbDatepickerConfig,
@@ -28,6 +29,7 @@ export class GlobeNgbDatepickerConfig extends NgbDatepickerConfig {
 }
 
 const NGB_MODULES = [
+  NgbCollapseModule,
   NgbModalModule,
   NgbDatepickerModule,
   NgbDropdownModule,

--- a/frontend/src/app/income-source-edit/income-source-edit.component.spec.ts
+++ b/frontend/src/app/income-source-edit/income-source-edit.component.spec.ts
@@ -9,7 +9,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { of } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ComponentTester, speculoosMatchers } from 'ngx-speculoos';
+import { ComponentTester } from 'ngx-speculoos';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
 import { ValdemortModule } from 'ngx-valdemort';
 import { PageTitleDirective } from '../page-title.directive';
@@ -58,8 +58,6 @@ describe('IncomeSourceEditComponent', () => {
     declarations: [IncomeSourceEditComponent, ValidationDefaultsComponent, PageTitleDirective]
   })
   class TestModule {}
-
-  beforeEach(() => jasmine.addMatchers(speculoosMatchers));
 
   describe('in creation mode', () => {
     const activatedRoute = {

--- a/frontend/src/app/menu/menu.component.html
+++ b/frontend/src/app/menu/menu.component.html
@@ -6,7 +6,7 @@
   <button type="button" class="navbar-toggler" (click)="toggleNavbar()">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <div id="navbar" class="navbar-collapse" [class.collapse]="navbarCollapsed">
+  <div id="navbar" class="collapse navbar-collapse" [ngbCollapse]="navbarCollapsed">
     <ng-container *ngIf="user">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">

--- a/frontend/src/app/menu/menu.component.spec.ts
+++ b/frontend/src/app/menu/menu.component.spec.ts
@@ -129,7 +129,7 @@ describe('MenuComponent', () => {
 
     tester.userDropDown.click();
 
-    expect(tester.changePasswordLink).not.toBeNull();
+    expect(tester.changePasswordLink).toBeVisible();
   });
 
   it('should navigate to the users page if admin', () => {
@@ -139,7 +139,9 @@ describe('MenuComponent', () => {
 
     tester.detectChanges();
 
-    expect(tester.usersLink).not.toBeNull();
+    tester.userDropDown.click();
+
+    expect(tester.usersLink).toBeVisible();
   });
 
   it('should unsubscribe on destroy', () => {
@@ -158,7 +160,7 @@ describe('MenuComponent', () => {
     spyOn(tester.componentInstance, 'logout').and.callFake(event => event.preventDefault());
 
     tester.userDropDown.click();
-    expect(tester.logout).not.toBeNull();
+    expect(tester.logout).toBeVisible();
     tester.logout.click();
 
     expect(tester.componentInstance.logout).toHaveBeenCalled();

--- a/frontend/src/app/menu/menu.component.spec.ts
+++ b/frontend/src/app/menu/menu.component.spec.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 import { MenuComponent } from './menu.component';
 import { UserModel } from '../models/user.model';
 import { CurrentUserService } from '../current-user/current-user.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ComponentTester } from 'ngx-speculoos';
 import { Router } from '@angular/router';
 
@@ -51,7 +51,7 @@ describe('MenuComponent', () => {
     fakeRouter = jasmine.createSpyObj<Router>('Router', ['navigate']);
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, GlobeNgbModule],
+      imports: [RouterTestingModule, GlobeNgbTestingModule],
       declarations: [MenuComponent],
       providers: [{ provide: CurrentUserService, useValue: fakeUserService }]
     });
@@ -82,12 +82,12 @@ describe('MenuComponent', () => {
     tester.detectChanges();
 
     expect(tester.navbar).not.toBeNull();
-    expect(tester.navbar).toHaveClass('collapse');
+    expect(tester.navbar).not.toHaveClass('show');
 
     expect(tester.toggler).not.toBeNull();
     tester.toggler.click();
 
-    expect(tester.navbar).not.toHaveClass('collapse');
+    expect(tester.navbar).toHaveClass('show');
   });
 
   it('should listen to userEvents in ngOnInit', fakeAsync(() => {

--- a/frontend/src/app/navigation-progress/navigation-progress.component.spec.ts
+++ b/frontend/src/app/navigation-progress/navigation-progress.component.spec.ts
@@ -12,7 +12,7 @@ import {
   RouterEvent
 } from '@angular/router';
 import { Subject } from 'rxjs';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 
 class NavigationProgressComponentTester extends ComponentTester<NavigationProgressComponent> {
   constructor() {
@@ -48,7 +48,7 @@ describe('NavigationProgressComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [NavigationProgressComponent],
-      imports: [GlobeNgbModule.forRoot()],
+      imports: [GlobeNgbTestingModule],
       providers: [{ provide: Router, useValue: fakeRouter }]
     });
 

--- a/frontend/src/app/password-reset/password-reset.component.spec.ts
+++ b/frontend/src/app/password-reset/password-reset.component.spec.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { UserWithPasswordModel } from '../models/user-with-password.model';
 import { HttpClientModule } from '@angular/common/http';
 import { UserService } from '../user.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
 import { ComponentTester } from 'ngx-speculoos';
@@ -42,7 +42,7 @@ describe('PasswordResetComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientModule, GlobeNgbModule.forRoot()],
+      imports: [HttpClientModule, GlobeNgbTestingModule],
       declarations: [PasswordResetComponent, PageTitleDirective],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },

--- a/frontend/src/app/person-death/person-death.component.spec.ts
+++ b/frontend/src/app/person-death/person-death.component.spec.ts
@@ -11,7 +11,7 @@ import { ValdemortModule } from 'ngx-valdemort';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { LOCALE_ID } from '@angular/core';
 
@@ -43,7 +43,7 @@ describe('PersonDeathComponent', () => {
       declarations: [PersonDeathComponent, FullnamePipe],
       imports: [
         HttpClientTestingModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         ValdemortModule,
         RouterTestingModule,
         ReactiveFormsModule

--- a/frontend/src/app/person-edit/person-edit.component.html
+++ b/frontend/src/app/person-edit/person-edit.component.html
@@ -155,7 +155,7 @@
     </div>
   </div>
 
-  <div *ngIf="personForm.value.mediationEnabled">
+  <div [ngbCollapse]="!personForm.value.mediationEnabled" id="mediation-section">
     <div class="form-group row">
       <label for="mediationCode" class="col-sm-3 col-form-label">Code de médiation</label>
       <div class="col-sm-9 text-muted form-control-static" id="mediationCode">
@@ -394,7 +394,8 @@
       </div>
     </div>
     <div
-      *ngIf="!['UNKNOWN', 'NONE', 'EMERGENCY'].includes(personForm.value.housing)"
+      id="housingSpace-section"
+      [ngbCollapse]="['UNKNOWN', 'NONE', 'EMERGENCY'].includes(personForm.value.housing)"
       class="form-group row"
     >
       <label for="housingSpace" class="col-sm-3 col-form-label"
@@ -578,32 +579,34 @@
         </div>
       </div>
     </div>
-    <div class="form-group row" *ngIf="personForm.value.fiscalStatus !== 'UNKNOWN'">
-      <label for="fiscalNumber" class="col-sm-3 col-form-label">N° fiscal</label>
-      <div class="col-sm-9">
-        <input
-          class="form-control"
-          id="fiscalNumber"
-          placeholder="13 chiffres"
-          formControlName="fiscalNumber"
-        />
-        <val-errors controlName="fiscalNumber" label="Le n° fiscal">
-          <ng-template valError="pattern" let-label
-            >{{ label }} doit être composé de 13 chiffres</ng-template
-          >
-        </val-errors>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-9 offset-sm-3">
-        <div *ngIf="personForm.value.fiscalStatus !== 'UNKNOWN'" class="form-check">
+    <div id="fiscal-section" [ngbCollapse]="personForm.value.fiscalStatus === 'UNKNOWN'">
+      <div class="form-group row">
+        <label for="fiscalNumber" class="col-sm-3 col-form-label">N° fiscal</label>
+        <div class="col-sm-9">
           <input
-            type="checkbox"
-            class="form-check-input"
-            id="fiscalStatusUpToDate"
-            formControlName="fiscalStatusUpToDate"
+            class="form-control"
+            id="fiscalNumber"
+            placeholder="13 chiffres"
+            formControlName="fiscalNumber"
           />
-          <label class="form-check-label" for="fiscalStatusUpToDate">A jour</label>
+          <val-errors controlName="fiscalNumber" label="Le n° fiscal">
+            <ng-template valError="pattern" let-label
+              >{{ label }} doit être composé de 13 chiffres</ng-template
+            >
+          </val-errors>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-9 offset-sm-3">
+          <div class="form-check">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              id="fiscalStatusUpToDate"
+              formControlName="fiscalStatusUpToDate"
+            />
+            <label class="form-check-label" for="fiscalStatusUpToDate">A jour</label>
+          </div>
         </div>
       </div>
     </div>
@@ -652,7 +655,7 @@
       </div>
     </div>
 
-    <ng-container *ngIf="personForm.value.passportStatus === 'PASSPORT'">
+    <div id="passport-section" [ngbCollapse]="personForm.value.passportStatus !== 'PASSPORT'">
       <div class="form-group row">
         <label for="passportNumber" class="col-sm-3 col-form-label">N° de passeport</label>
         <div class="col-sm-9">
@@ -701,7 +704,7 @@
           </div>
         </div>
       </div>
-    </ng-container>
+    </div>
   </div>
 
   <div class="row mt-5">

--- a/frontend/src/app/person-edit/person-edit.component.spec.ts
+++ b/frontend/src/app/person-edit/person-edit.component.spec.ts
@@ -31,7 +31,7 @@ import { FullnamePipe } from '../fullname.pipe';
 import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { filter, map } from 'rxjs/operators';
 import { CountryModel } from '../models/country.model';
-import { ComponentTester, speculoosMatchers, TestInput } from 'ngx-speculoos';
+import { ComponentTester, TestInput } from 'ngx-speculoos';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
 import { ValdemortModule } from 'ngx-valdemort';
 import { DisplayResidencePermitPipe } from '../display-residence-permit.pipe';
@@ -627,7 +627,7 @@ describe('PersonEditComponent', () => {
       tester.fiscalNumber.fillWith('INVALID');
       tester.fiscalStatus('UNKNOWN').check();
 
-      expect(tester.fiscalSection).not.toHaveClass('show');
+      expect(tester.fiscalSection).not.toBeVisible();
       expect(tester.fiscalNumber).toHaveValue('');
     });
 
@@ -695,8 +695,6 @@ describe('PersonEditComponent', () => {
       personService = TestBed.inject(PersonService);
     });
 
-    beforeEach(() => jasmine.addMatchers(speculoosMatchers));
-
     it('should have a title', () => {
       const tester = new PersonEditTester();
       tester.detectChanges();
@@ -735,12 +733,11 @@ describe('PersonEditComponent', () => {
 
       expect(tester.mediationEnabled(true)).not.toBeChecked();
       expect(tester.mediationEnabled(false)).toBeChecked();
-      expect(tester.mediationSection).toHaveClass('collapse');
-      expect(tester.mediationSection).not.toHaveClass('show');
+      expect(tester.mediationSection).not.toBeVisible();
 
       tester.mediationEnabled(true).check();
 
-      expect(tester.mediationSection).toHaveClass('show');
+      expect(tester.mediationSection).toBeVisible();
 
       expect(tester.mediationCode).toHaveText(' Généré automatiquement ');
       expect(tester.firstMediationAppointmentDate).toHaveValue('');
@@ -751,12 +748,11 @@ describe('PersonEditComponent', () => {
       expect(tester.entryDate).toHaveValue('');
       expect(tester.entryType).toHaveSelectedValue('UNKNOWN');
       expect(tester.housing).toHaveSelectedValue('UNKNOWN');
-      expect(tester.housingSpaceSection).not.toHaveClass('show');
+      expect(tester.housingSpaceSection).not.toBeVisible();
       expect(tester.housingSpace).toHaveValue('');
       expect(tester.hostName).toHaveValue('');
       expect(tester.fiscalStatus('UNKNOWN')).toBeChecked();
-      expect(tester.fiscalSection).toHaveClass('collapse');
-      expect(tester.fiscalSection).not.toHaveClass('show');
+      expect(tester.fiscalSection).not.toBeVisible();
       expect(tester.fiscalNumber).toHaveValue('');
       expect(tester.fiscalStatusUpToDate).not.toBeChecked();
       expect(tester.accompanying).toHaveValue('');
@@ -768,8 +764,7 @@ describe('PersonEditComponent', () => {
       expect(tester.healthInsuranceStartDate).toBeFalsy();
       expect(tester.nationality).toHaveValue('');
       expect(tester.passportStatus('UNKNOWN')).toBeChecked();
-      expect(tester.passportSection).toHaveClass('collapse');
-      expect(tester.passportSection).not.toHaveClass('show');
+      expect(tester.passportSection).not.toBeVisible();
       expect(tester.visa).toHaveSelectedValue('UNKNOWN');
       expect(tester.residencePermit).toHaveSelectedValue('UNKNOWN');
       expect(tester.residencePermitDepositDate).toHaveValue('');
@@ -810,12 +805,11 @@ describe('PersonEditComponent', () => {
       tester.entryType.selectLabel('Irrégulière');
       tester.firstMediationAppointmentDate.fillWith('02/02/2017');
       tester.housing.selectLabel('Aucun');
-      expect(tester.housingSpaceSection).toHaveClass('collapse');
-      expect(tester.housingSpaceSection).not.toHaveClass('show');
+      expect(tester.housingSpaceSection).not.toBeVisible();
       tester.housing.selectLabel('115');
-      expect(tester.housingSpaceSection).not.toHaveClass('show');
+      expect(tester.housingSpaceSection).not.toBeVisible();
       tester.housing.selectLabel('F0');
-      expect(tester.housingSpaceSection).toHaveClass('show');
+      expect(tester.housingSpaceSection).toBeVisible();
       tester.housingSpace.fillWith('30');
       tester.hostName.fillWith('Bruno');
       tester.accompanying.fillWith('Paulette');
@@ -843,7 +837,7 @@ describe('PersonEditComponent', () => {
       tester.firstTypeaheadOption.click();
 
       tester.passportStatus('PASSPORT').check();
-      expect(tester.passportSection).toHaveClass('show');
+      expect(tester.passportSection).toBeVisible();
       tester.passportNumber.fillWith('P1');
       tester.passportValidityStartDate.fillWith('01/09/2019');
       tester.passportValidityEndDate.fillWith('01/09/2024');

--- a/frontend/src/app/person-edit/person-edit.component.spec.ts
+++ b/frontend/src/app/person-edit/person-edit.component.spec.ts
@@ -28,7 +28,7 @@ import { DisplayFiscalStatusPipe } from '../display-fiscal-status.pipe';
 import { DisplayHealthCareCoveragePipe } from '../display-health-care-coverage.pipe';
 import { DisplayHealthInsurancePipe } from '../display-health-insurance.pipe';
 import { FullnamePipe } from '../fullname.pipe';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { filter, map } from 'rxjs/operators';
 import { CountryModel } from '../models/country.model';
 import { ComponentTester, speculoosMatchers, TestInput } from 'ngx-speculoos';
@@ -77,8 +77,12 @@ class PersonEditTester extends ComponentTester<PersonEditComponent> {
     return this.input(`#mediationEnabled${yesOrNo}`);
   }
 
+  get mediationSection() {
+    return this.element('#mediation-section');
+  }
+
   get mediationCode() {
-    return this.element('#mediationCode');
+    return this.mediationSection.element('#mediationCode');
   }
 
   get address() {
@@ -98,11 +102,11 @@ class PersonEditTester extends ComponentTester<PersonEditComponent> {
   }
 
   get firstMediationAppointmentDate() {
-    return this.input('#firstMediationAppointmentDate');
+    return this.mediationSection.input('#firstMediationAppointmentDate');
   }
 
   get maritalStatus() {
-    return this.select('#maritalStatus');
+    return this.mediationSection.select('#maritalStatus');
   }
 
   spouseType(type: 'none' | 'spouse' | 'partner') {
@@ -118,107 +122,119 @@ class PersonEditTester extends ComponentTester<PersonEditComponent> {
   }
 
   get entryDate() {
-    return this.input('#entryDate');
+    return this.mediationSection.input('#entryDate');
   }
 
   get entryType() {
-    return this.select('#entryType');
+    return this.mediationSection.select('#entryType');
   }
 
   get housing() {
-    return this.select('#housing');
+    return this.mediationSection.select('#housing');
+  }
+
+  get housingSpaceSection() {
+    return this.mediationSection.element('#housingSpace-section');
   }
 
   get housingSpace() {
-    return this.input('#housingSpace');
+    return this.housingSpaceSection.input('#housingSpace');
   }
 
   get hostName() {
-    return this.input('#hostName');
+    return this.mediationSection.input('#hostName');
   }
 
   fiscalStatus(status: FiscalStatus) {
-    return this.input(`#fiscalStatus${status}`);
+    return this.mediationSection.input(`#fiscalStatus${status}`);
+  }
+
+  get fiscalSection() {
+    return this.mediationSection.element('#fiscal-section');
   }
 
   get fiscalNumber() {
-    return this.input('#fiscalNumber');
+    return this.fiscalSection.input('#fiscalNumber');
   }
 
   get fiscalStatusUpToDate() {
-    return this.input('#fiscalStatusUpToDate');
+    return this.fiscalSection.input('#fiscalStatusUpToDate');
   }
 
   get healthCareCoverage() {
-    return this.select('#healthCareCoverage');
+    return this.mediationSection.select('#healthCareCoverage');
   }
 
   get healthCareCoverageStartDate() {
-    return this.input('#healthCareCoverageStartDate');
+    return this.mediationSection.input('#healthCareCoverageStartDate');
   }
 
   get healthInsurance() {
-    return this.select('#healthInsurance');
+    return this.mediationSection.select('#healthInsurance');
   }
 
   get healthInsuranceStartDate() {
-    return this.input('#healthInsuranceStartDate');
+    return this.mediationSection.input('#healthInsuranceStartDate');
   }
 
   get accompanying() {
-    return this.input('#accompanying');
+    return this.mediationSection.input('#accompanying');
   }
 
   get socialSecurityNumber() {
-    return this.input('#socialSecurityNumber');
+    return this.mediationSection.input('#socialSecurityNumber');
   }
 
   get cafNumber() {
-    return this.input('#cafNumber');
+    return this.mediationSection.input('#cafNumber');
   }
 
   get nationality() {
-    return this.input('#nationality');
+    return this.mediationSection.input('#nationality');
   }
 
   passportStatus(status: PassportStatus) {
-    return this.input(`#passportStatus${status}`);
+    return this.mediationSection.input(`#passportStatus${status}`);
+  }
+
+  get passportSection() {
+    return this.mediationSection.element('#passport-section');
   }
 
   get passportNumber() {
-    return this.input('#passportNumber');
+    return this.passportSection.input('#passportNumber');
   }
 
   get passportValidityStartDate() {
-    return this.input('#passportValidityStartDate');
+    return this.passportSection.input('#passportValidityStartDate');
   }
 
   get passportValidityEndDate() {
-    return this.input('#passportValidityEndDate');
+    return this.passportSection.input('#passportValidityEndDate');
   }
 
   get visa() {
-    return this.select('#visa');
+    return this.mediationSection.select('#visa');
   }
 
   get residencePermit() {
-    return this.select('#residencePermit');
+    return this.mediationSection.select('#residencePermit');
   }
 
   get residencePermitDepositDate() {
-    return this.input('#residencePermitDepositDate');
+    return this.mediationSection.input('#residencePermitDepositDate');
   }
 
   get residencePermitRenewalDate() {
-    return this.input('#residencePermitRenewalDate');
+    return this.mediationSection.input('#residencePermitRenewalDate');
   }
 
   get residencePermitValidityStartDate() {
-    return this.input('#residencePermitValidityStartDate');
+    return this.mediationSection.input('#residencePermitValidityStartDate');
   }
 
   get residencePermitValidityEndDate() {
-    return this.input('#residencePermitValidityEndDate');
+    return this.mediationSection.input('#residencePermitValidityEndDate');
   }
 
   get firstTypeaheadOption() {
@@ -287,7 +303,7 @@ describe('PersonEditComponent', () => {
       HttpClientModule,
       ReactiveFormsModule,
       RouterTestingModule,
-      GlobeNgbModule.forRoot(),
+      GlobeNgbTestingModule,
       ValdemortModule
     ],
     declarations: [
@@ -607,13 +623,12 @@ describe('PersonEditComponent', () => {
     it('should set the fiscal number to null if invalid when setting the fiscal status to UNKNONW', () => {
       const tester = new PersonEditTester();
       tester.detectChanges();
-      const component = tester.componentInstance;
 
       tester.fiscalNumber.fillWith('INVALID');
       tester.fiscalStatus('UNKNOWN').check();
 
-      expect(tester.fiscalNumber).toBeNull();
-      expect(component.personForm.get('fiscalNumber').value).toBeNull();
+      expect(tester.fiscalSection).not.toHaveClass('show');
+      expect(tester.fiscalNumber).toHaveValue('');
     });
 
     it('should set the passport fields to null if passport status is not PASSPORT', () => {
@@ -720,31 +735,12 @@ describe('PersonEditComponent', () => {
 
       expect(tester.mediationEnabled(true)).not.toBeChecked();
       expect(tester.mediationEnabled(false)).toBeChecked();
-
-      const mediationDependantIds = [
-        'mediationCode',
-        'firstMediationAppointmentDate',
-        'maritalStatus',
-        'entryDate',
-        'entryType',
-        'housing',
-        'hostName',
-        'fiscalStatusUNKNOWN',
-        'socialSecurityNumber',
-        'accompanying',
-        'cafNumber',
-        'nationality'
-      ];
-
-      mediationDependantIds.forEach(id => {
-        expect(tester.element(`#${id}`)).toBeNull(`#${id} should be absent`);
-      });
+      expect(tester.mediationSection).toHaveClass('collapse');
+      expect(tester.mediationSection).not.toHaveClass('show');
 
       tester.mediationEnabled(true).check();
 
-      mediationDependantIds.forEach(id => {
-        expect(tester.element(`#${id}`)).not.toBeNull(`#${id} should be present`);
-      });
+      expect(tester.mediationSection).toHaveClass('show');
 
       expect(tester.mediationCode).toHaveText(' Généré automatiquement ');
       expect(tester.firstMediationAppointmentDate).toHaveValue('');
@@ -755,11 +751,14 @@ describe('PersonEditComponent', () => {
       expect(tester.entryDate).toHaveValue('');
       expect(tester.entryType).toHaveSelectedValue('UNKNOWN');
       expect(tester.housing).toHaveSelectedValue('UNKNOWN');
-      expect(tester.housingSpace).toBeFalsy();
+      expect(tester.housingSpaceSection).not.toHaveClass('show');
+      expect(tester.housingSpace).toHaveValue('');
       expect(tester.hostName).toHaveValue('');
       expect(tester.fiscalStatus('UNKNOWN')).toBeChecked();
-      expect(tester.fiscalNumber).toBeFalsy();
-      expect(tester.fiscalStatusUpToDate).toBeFalsy();
+      expect(tester.fiscalSection).toHaveClass('collapse');
+      expect(tester.fiscalSection).not.toHaveClass('show');
+      expect(tester.fiscalNumber).toHaveValue('');
+      expect(tester.fiscalStatusUpToDate).not.toBeChecked();
       expect(tester.accompanying).toHaveValue('');
       expect(tester.socialSecurityNumber).toHaveValue('');
       expect(tester.cafNumber).toHaveValue('');
@@ -769,9 +768,8 @@ describe('PersonEditComponent', () => {
       expect(tester.healthInsuranceStartDate).toBeFalsy();
       expect(tester.nationality).toHaveValue('');
       expect(tester.passportStatus('UNKNOWN')).toBeChecked();
-      expect(tester.passportNumber).toBeNull();
-      expect(tester.passportValidityStartDate).toBeNull();
-      expect(tester.passportValidityEndDate).toBeNull();
+      expect(tester.passportSection).toHaveClass('collapse');
+      expect(tester.passportSection).not.toHaveClass('show');
       expect(tester.visa).toHaveSelectedValue('UNKNOWN');
       expect(tester.residencePermit).toHaveSelectedValue('UNKNOWN');
       expect(tester.residencePermitDepositDate).toHaveValue('');
@@ -812,11 +810,12 @@ describe('PersonEditComponent', () => {
       tester.entryType.selectLabel('Irrégulière');
       tester.firstMediationAppointmentDate.fillWith('02/02/2017');
       tester.housing.selectLabel('Aucun');
-      expect(tester.housingSpace).toBeFalsy();
+      expect(tester.housingSpaceSection).toHaveClass('collapse');
+      expect(tester.housingSpaceSection).not.toHaveClass('show');
       tester.housing.selectLabel('115');
-      expect(tester.housingSpace).toBeFalsy();
+      expect(tester.housingSpaceSection).not.toHaveClass('show');
       tester.housing.selectLabel('F0');
-      expect(tester.housingSpace).toBeTruthy();
+      expect(tester.housingSpaceSection).toHaveClass('show');
       tester.housingSpace.fillWith('30');
       tester.hostName.fillWith('Bruno');
       tester.accompanying.fillWith('Paulette');
@@ -844,6 +843,7 @@ describe('PersonEditComponent', () => {
       tester.firstTypeaheadOption.click();
 
       tester.passportStatus('PASSPORT').check();
+      expect(tester.passportSection).toHaveClass('show');
       tester.passportNumber.fillWith('P1');
       tester.passportValidityStartDate.fillWith('01/09/2019');
       tester.passportValidityEndDate.fillWith('01/09/2024');

--- a/frontend/src/app/person-family-edit/person-family-edit.component.spec.ts
+++ b/frontend/src/app/person-family-edit/person-family-edit.component.spec.ts
@@ -7,7 +7,7 @@ import { FullnamePipe } from '../fullname.pipe';
 import { FamilyService } from '../family.service';
 import { PersonFamilyEditComponent } from './person-family-edit.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { FamilyCommand } from '../models/family.command';
 import { FamilyModel } from '../models/family.model';
 import { of } from 'rxjs';
@@ -88,7 +88,7 @@ describe('PersonFamilyEditComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         ReactiveFormsModule,
-        GlobeNgbModule.forRoot()
+        GlobeNgbTestingModule
       ]
     });
 

--- a/frontend/src/app/person-family/person-family.component.spec.ts
+++ b/frontend/src/app/person-family/person-family.component.spec.ts
@@ -6,7 +6,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ConfirmService } from '../confirm.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { FamilyModel } from '../models/family.model';
 import { By } from '@angular/platform-browser';
 import { EMPTY, of } from 'rxjs';
@@ -58,7 +58,7 @@ describe('PersonFamilyComponent', () => {
         ConfirmService,
         { provide: ActivatedRoute, useFactory: () => route }
       ],
-      imports: [HttpClientTestingModule, RouterTestingModule, GlobeNgbModule.forRoot()]
+      imports: [HttpClientTestingModule, RouterTestingModule, GlobeNgbTestingModule]
     });
 
     currentPersonService = TestBed.inject(CurrentPersonService);

--- a/frontend/src/app/person-files/person-files.component.spec.ts
+++ b/frontend/src/app/person-files/person-files.component.spec.ts
@@ -10,7 +10,7 @@ import { FileSizePipe } from '../file-size.pipe';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of, Subject } from 'rxjs';
 import { By, Title } from '@angular/platform-browser';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { PageTitleDirective } from '../page-title.directive';
 import { FullnamePipe } from '../fullname.pipe';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -52,7 +52,7 @@ describe('PersonFilesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule, GlobeNgbModule.forRoot()],
+      imports: [HttpClientTestingModule, RouterTestingModule, GlobeNgbTestingModule],
       declarations: [PersonFilesComponent, FileSizePipe, PageTitleDirective, FullnamePipe]
     });
 

--- a/frontend/src/app/person-layout/person-layout.component.spec.ts
+++ b/frontend/src/app/person-layout/person-layout.component.spec.ts
@@ -10,7 +10,7 @@ import { of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MembershipModel } from '../models/membership.model';
 import { MembershipService } from '../membership.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ComponentTester } from 'ngx-speculoos';
 import { LOCALE_ID } from '@angular/core';
 import { CurrentPersonService } from '../current-person.service';
@@ -51,7 +51,7 @@ describe('PersonLayoutComponent', () => {
     } as PersonModel;
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientTestingModule, GlobeNgbModule.forRoot()],
+      imports: [RouterTestingModule, HttpClientTestingModule, GlobeNgbTestingModule],
       declarations: [PersonLayoutComponent, FullnamePipe],
       providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }]
     });

--- a/frontend/src/app/person-memberships/person-memberships.component.spec.ts
+++ b/frontend/src/app/person-memberships/person-memberships.component.spec.ts
@@ -6,7 +6,7 @@ import { MembershipService } from '../membership.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { PersonMembershipsComponent } from './person-memberships.component';
 import { DateTime } from 'luxon';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { DisplayPaymentModePipe, PAYMENT_MODE_TRANSLATIONS } from '../display-payment-mode.pipe';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ConfirmService } from '../confirm.service';
@@ -101,7 +101,7 @@ describe('PersonMembershipsComponent', () => {
       ],
       imports: [
         HttpClientTestingModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         ReactiveFormsModule,
         ValdemortModule
       ]

--- a/frontend/src/app/person-network-members/person-network-members.component.spec.ts
+++ b/frontend/src/app/person-network-members/person-network-members.component.spec.ts
@@ -4,7 +4,7 @@ import { PersonNetworkMembersComponent } from './person-network-members.componen
 import { ActivatedRoute } from '@angular/router';
 import { NetworkMemberModel } from '../models/network-member.model';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { DisplayNetworkMemberTypePipe } from '../display-network-member-type.pipe';
 import { ConfirmService } from '../confirm.service';
@@ -96,7 +96,7 @@ describe('PersonNetworkMembersComponent', () => {
       imports: [
         HttpClientTestingModule,
         ReactiveFormsModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         ValdemortModule
       ]
     });

--- a/frontend/src/app/person-notes/person-notes.component.spec.ts
+++ b/frontend/src/app/person-notes/person-notes.component.spec.ts
@@ -12,7 +12,7 @@ import { EMPTY, of, Subject } from 'rxjs';
 import { UserModel } from '../models/user.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { ComponentTester } from 'ngx-speculoos';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -78,7 +78,7 @@ describe('PersonNotesComponent', () => {
         CurrentUserModule.forRoot(),
         ReactiveFormsModule,
         HttpClientModule,
-        GlobeNgbModule.forRoot()
+        GlobeNgbTestingModule
       ],
       declarations: [PersonNotesComponent, NoteComponent, TestComponent]
     });

--- a/frontend/src/app/person-resources/person-resources.component.spec.ts
+++ b/frontend/src/app/person-resources/person-resources.component.spec.ts
@@ -10,7 +10,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { LOCALE_ID } from '@angular/core';
 import { ChargeModel } from '../models/charge.model';
 import { ChargeService } from '../charge.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { EMPTY, of } from 'rxjs';
 import { PerUnitRevenueInformationModel } from '../models/per-unit-revenue-information.model';
 import { PerUnitRevenueInformationService } from '../per-unit-revenue-information.service';
@@ -124,7 +124,7 @@ describe('PersonResourcesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule, RouterTestingModule, GlobeNgbModule.forRoot()],
+      imports: [HttpClientModule, RouterTestingModule, GlobeNgbTestingModule],
       declarations: [PersonResourcesComponent, PageTitleDirective, FullnamePipe],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },

--- a/frontend/src/app/person-wedding-events/person-wedding-events.component.spec.ts
+++ b/frontend/src/app/person-wedding-events/person-wedding-events.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { PersonWeddingEventsComponent } from './person-wedding-events.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { PersonModel } from '../models/person.model';
 import { WeddingEventModel } from '../models/wedding-event.model';
 import { WeddingEventService } from '../wedding-event.service';
@@ -118,7 +118,7 @@ describe('PersonWeddingEventsComponent', () => {
       ],
       imports: [
         ReactiveFormsModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         ValdemortModule,
         HttpClientTestingModule
       ],

--- a/frontend/src/app/person/person.component.spec.ts
+++ b/frontend/src/app/person/person.component.spec.ts
@@ -18,7 +18,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ConfirmService } from '../confirm.service';
 import { PersonService } from '../person.service';
 import { FullnamePipe } from '../fullname.pipe';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { EMPTY, of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
 import { DisplayEntryTypePipe } from '../display-entry-type.pipe';
@@ -198,7 +198,7 @@ describe('PersonComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientModule, GlobeNgbModule.forRoot()],
+      imports: [RouterTestingModule, HttpClientModule, GlobeNgbTestingModule],
       declarations: [
         PersonComponent,
         DisplayGenderPipe,

--- a/frontend/src/app/profile/profile.component.spec.ts
+++ b/frontend/src/app/profile/profile.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { ProfileComponent } from './profile.component';
 import { ComponentTester, fakeRoute, fakeSnapshot } from 'ngx-speculoos';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -52,7 +52,7 @@ describe('ProfileComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ProfileComponent],
       imports: [
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         HttpClientTestingModule,
         RouterTestingModule,
         ReactiveFormsModule,

--- a/frontend/src/app/spent-time-add/spent-time-add.component.scss
+++ b/frontend/src/app/spent-time-add/spent-time-add.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/spent-time-statistics/spent-time-statistics.component.spec.ts
+++ b/frontend/src/app/spent-time-statistics/spent-time-statistics.component.spec.ts
@@ -12,7 +12,7 @@ import { SpentTimeStatisticsModel } from '../models/spent-time-statistics.model'
 import { UserModel } from '../models/user.model';
 import { ChartColor } from 'chart.js';
 import { By } from '@angular/platform-browser';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { EMPTY, of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
@@ -81,7 +81,7 @@ describe('SpentTimeStatisticsComponent', () => {
           }
         ]),
         ReactiveFormsModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         CurrentUserModule.forRoot(),
         HttpClientModule
       ],

--- a/frontend/src/app/spent-times/spent-times.component.html
+++ b/frontend/src/app/spent-times/spent-times.component.html
@@ -1,4 +1,4 @@
-<ul>
+<ul class="mb-0">
   <li *ngFor="let spentTime of spentTimes">
     {{ spentTime.creationInstant | date: 'medium' }}: {{ spentTime.minutes | duration }} par
     {{ spentTime.creator.login }}

--- a/frontend/src/app/spent-times/spent-times.component.scss
+++ b/frontend/src/app/spent-times/spent-times.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/task-edit/task-edit.component.spec.ts
+++ b/frontend/src/app/task-edit/task-edit.component.spec.ts
@@ -12,7 +12,7 @@ import { TaskModel } from '../models/task.model';
 import { TaskCategoryModel } from '../models/task-category.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
 import { CurrentUserService } from '../current-user/current-user.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { of } from 'rxjs';
 import { ComponentTester } from 'ngx-speculoos';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
@@ -114,7 +114,7 @@ describe('TaskEditComponent', () => {
         CurrentUserModule.forRoot(),
         ReactiveFormsModule,
         RouterTestingModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
         HttpClientModule,
         ValdemortModule
       ],

--- a/frontend/src/app/tasks-page/tasks-page.component.spec.ts
+++ b/frontend/src/app/tasks-page/tasks-page.component.spec.ts
@@ -18,10 +18,11 @@ import { SpentTimeAddComponent } from '../spent-time-add/spent-time-add.componen
 import { DurationPipe } from '../duration.pipe';
 import { UserModel } from '../models/user.model';
 import { CurrentUserModule } from '../current-user/current-user.module';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { of } from 'rxjs';
 import { PageTitleDirective } from '../page-title.directive';
 import { ComponentTester } from 'ngx-speculoos';
+import { ReactiveFormsModule } from '@angular/forms';
 
 class TasksPageComponentTester extends ComponentTester<TasksPageComponent> {
   constructor() {
@@ -115,7 +116,8 @@ describe('TasksPageComponent', () => {
       imports: [
         CurrentUserModule.forRoot(),
         RouterTestingModule,
-        GlobeNgbModule.forRoot(),
+        GlobeNgbTestingModule,
+        ReactiveFormsModule,
         HttpClientModule
       ],
       declarations: [

--- a/frontend/src/app/tasks/tasks.component.html
+++ b/frontend/src/app/tasks/tasks.component.html
@@ -19,7 +19,7 @@
           ><span class="fa fa-times"></span> Annulée</small
         >
       </div>
-      <div *ngIf="task.opened" class="task-description">{{ task.model.description }}</div>
+      <div [ngbCollapse]="!task.opened" class="task-description">{{ task.model.description }}</div>
     </a>
     <div class="d-flex w-100 justify-content-between align-items-start">
       <div class="small text-muted">
@@ -58,8 +58,8 @@
             (spentTimeDeleted)="onSpentTimeDeleted($event)"
           ></gl-spent-times>
           <gl-spent-time-add
-            class="d-block mt-2"
-            *ngIf="task.addSpentTimeOpened"
+            class="mt-2"
+            [ngbCollapse]="!task.addSpentTimeOpened"
             [taskModel]="task.model"
             (spentTimeAdded)="onSpentTimeAdded($event)"
             (cancelled)="toggleAddSpentTime(task)"

--- a/frontend/src/app/tasks/tasks.component.spec.ts
+++ b/frontend/src/app/tasks/tasks.component.spec.ts
@@ -19,7 +19,7 @@ import { CurrentUserModule } from '../current-user/current-user.module';
 import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { of } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
-import { ComponentTester, speculoosMatchers } from 'ngx-speculoos';
+import { ComponentTester } from 'ngx-speculoos';
 
 @Component({
   template: '<gl-tasks [taskModels]="tasks" (taskClicked)="onTaskClicked($event)"></gl-tasks>'
@@ -205,7 +205,6 @@ describe('TasksComponent', () => {
       tester = new TasksComponentTester();
       tester.componentInstance.tasks = tasks;
       tester.detectChanges();
-      jasmine.addMatchers(speculoosMatchers);
     });
 
     it('should display everything but the description and the no task message when not opened', () => {
@@ -215,7 +214,7 @@ describe('TasksComponent', () => {
       expect(text).toContain('#Various');
       expect(text).toContain("aujourd'hui");
       expect(tester.description).toContainText('Some description');
-      expect(tester.description).not.toHaveClass('show');
+      expect(tester.description).not.toBeVisible();
       expect(text).toContain('Assignée à admin');
       expect(text).toContain('Créée par user2');
       expect(text).toContain('Concerne JB Nizet');
@@ -223,15 +222,14 @@ describe('TasksComponent', () => {
     });
 
     it('should add a spent time, and close on cancel', () => {
-      expect(tester.addSpentTime).toHaveClass('collapse');
-      expect(tester.addSpentTime).not.toHaveClass('show');
+      expect(tester.addSpentTime).not.toBeVisible();
       tester.addSpentTimeLink.click();
 
-      expect(tester.addSpentTime).toHaveClass('show');
+      expect(tester.addSpentTime).toBeVisible();
       tester.addSpentTimeComponent.cancel();
       tester.detectChanges();
 
-      expect(tester.addSpentTime).not.toHaveClass('show');
+      expect(tester.addSpentTime).not.toBeVisible();
     });
 
     it('should add a spent time, recompute total spent time and close when added', () => {
@@ -248,7 +246,7 @@ describe('TasksComponent', () => {
       });
       tester.detectChanges();
 
-      expect(tester.addSpentTime).not.toHaveClass('show');
+      expect(tester.addSpentTime).not.toBeVisible();
       expect(tester.spentTimesLink).toBeTruthy();
       expect(tester.spentTimesLink.textContent).toContain('1h40m');
     });

--- a/frontend/src/app/user-edit/user-edit.component.spec.ts
+++ b/frontend/src/app/user-edit/user-edit.component.spec.ts
@@ -9,7 +9,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { UserService } from '../user.service';
-import { GlobeNgbModule } from '../globe-ngb/globe-ngb.module';
+import { GlobeNgbTestingModule } from '../globe-ngb/globe-ngb-testing.module';
 import { of } from 'rxjs';
 import { ValidationDefaultsComponent } from '../validation-defaults/validation-defaults.component';
 import { ValdemortModule } from 'ngx-valdemort';
@@ -54,7 +54,7 @@ describe('UserEditComponent', () => {
       HttpClientModule,
       ReactiveFormsModule,
       RouterTestingModule,
-      GlobeNgbModule.forRoot(),
+      GlobeNgbTestingModule,
       ValdemortModule
     ],
     declarations: [UserEditComponent, ValidationDefaultsComponent, PageTitleDirective]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1155,10 +1155,10 @@
     merge-source-map "^1.1.0"
     schema-utils "^2.7.0"
 
-"@ng-bootstrap/ng-bootstrap@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-7.0.0.tgz#3bfa62eb52fdb891b1ce693ea11c39127e2d1ab7"
-  integrity sha512-SxUaptGWJmCxM0d2Zy1mx7K7p/YBwGZ69NmmBQVY4BE6p5av0hWrVmv9rzzfBz0rhxU7RPZLor2Jpaoq8Xyl4w==
+"@ng-bootstrap/ng-bootstrap@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-8.0.0.tgz#7e1b9dc8a147e61ec964af430d1941be377bbe1e"
+  integrity sha512-v77Gfd8xHH+exq0WqIqVRlxbUEHdA/2+RUJenUP2IDTQN9E1rWl7O461/kosr+0XPuxPArHQJxhh/WsCYckcNg==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
- testing module to disable them in tests
- (closed) instead of (close) on alerts
- ngbCollapse introduced in several places (and tests updated accordingly)
- unrelated: use a button rather than a span to open datepicker

(draft because I don't want to rely on beta)
