### PR TITLE
build: upgrade node plugin and improve frontend build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,6 @@ jobs: # a collection of steps
       - run: sudo apt-get update
       - run: sudo apt-get install postgresql-client
       - run: psql -h localhost -f backend/database/database.sql -U postgres
-      - run: ./gradlew yarn_ngcc
+      - run: ./gradlew yarnNgcc
       - run: ./gradlew check jacocoTestReport build
-      - run: ./gradlew :frontend:yarn_codecov :frontend:yarn_bundlesize
+      - run: ./gradlew :frontend:yarnCodecov :frontend:yarnBundlesize

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,8 +6,6 @@
 /out-tsc
 # Only exists if Bazel was run
 /bazel-out
-tslint-result.txt
-prettier-result.txt
 
 # dependencies
 /node_modules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,9 @@
     "test": "ng test --code-coverage --no-progress --no-watch",
     "bundlesize": "bundlesize",
     "codecov": "codecov --root=..",
-    "lint": "ng lint > tslint-result.txt",
+    "lint": "mkdirp build && ng lint > build/tslint-result.txt",
     "format": "prettier --write \"src/**/*.+(ts|js|json|html|scss)\"",
-    "format:check": "prettier --check \"src/**/*.+(ts|js|json|html|scss)\" > prettier-result.txt 2>&1",
+    "format:check": "mkdirp build && prettier --check \"src/**/*.+(ts|js|json|html|scss)\" > build/prettier-result.txt 2>&1",
     "ngcc": "ngcc --properties es2015 browser module main --async false"
   },
   "private": true,


### PR DESCRIPTION
- avoid relying on automatic rules, and instead define tasks explicitly for less magic;
- use the default yarn task instead of redefining one;
- move reports to build dir