### PR TITLE
ci: add flag to apt-get in hope to fix issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs: # a collection of steps
 
       - checkout # check out source code to working directory
 
-      - run: sudo apt-get update
+      - run: sudo apt-get --allow-releaseinfo-change update
       - run: sudo apt-get install postgresql-client
       - run: psql -h localhost -f backend/database/database.sql -U postgres
       - run: ./gradlew yarnNgcc


### PR DESCRIPTION
```
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.6' to '10.10'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```